### PR TITLE
Fix bad repo links in README

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Welcome! Equip is a tiny and powerful PHP micro-framework created and maintained
 To install Equip, [use Composer](https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies).
 
 ```bash
-composer require equip/equip
+composer require equip/framework
 ```
 
 Subsequent examples will assume your project has a directory structure similar to this:
@@ -93,28 +93,28 @@ $injector->prepare('ClassName', function(ClassName $instance) {
 
 ## Configuration
 
-In Equip, configuration of the injector is encapsulated in classes implementing [`ConfigurationInterface`](https://github.com/equip/equip/blob/master/src/Configuration/ConfigurationInterface.php). This interface has a single method `apply()` that applies some configuration to a given Auryn `Injector` instance. The purpose of this is to allow for clean [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) and [reusability](https://en.wikipedia.org/wiki/Reusability) of configuration logic.
+In Equip, configuration of the injector is encapsulated in classes implementing [`ConfigurationInterface`](https://github.com/equip/framework/blob/master/src/Configuration/ConfigurationInterface.php). This interface has a single method `apply()` that applies some configuration to a given Auryn `Injector` instance. The purpose of this is to allow for clean [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) and [reusability](https://en.wikipedia.org/wiki/Reusability) of configuration logic.
 
-To facilitate ease of reuse for groupings of configuration, Equip provides a [`ConfigurationSet`](https://github.com/equip/equip/blob/master/src/Configuration/ConfigurationSet.php) class, which takes in a list of configuration classes and applies them to an injector instance.
+To facilitate ease of reuse for groupings of configuration, Equip provides a [`ConfigurationSet`](https://github.com/equip/framework/blob/master/src/Configuration/ConfigurationSet.php) class, which takes in a list of configuration classes and applies them to an injector instance.
 
-For a Equip application to function properly, the `Injector` instance it uses will need some configuration. This configuration is defined using the [`Application`](https://github.com/equip/equip/blob/master/src/Application.php) `setConfiguration()` method, which accepts an array of configuration classes or objects to be applied. It is also possible to provide a `ConfigurationSet` when calling `Application::build()` to be used as the default set.
+For a Equip application to function properly, the `Injector` instance it uses will need some configuration. This configuration is defined using the [`Application`](https://github.com/equip/framework/blob/master/src/Application.php) `setConfiguration()` method, which accepts an array of configuration classes or objects to be applied. It is also possible to provide a `ConfigurationSet` when calling `Application::build()` to be used as the default set.
 
 ### Default Configuration
 
 The following configurations are typically used by default:
 
-* [`AurynConfiguration`](https://github.com/equip/equip/blob/master/src/Configuration/AurynConfiguration.php) - Use the `Injector` instance as a singleton and to resolve [actions](https://github.com/pmjones/adr#controller-vs-action)
-* [`DiactorosConfiguration`](https://github.com/equip/equip/blob/master/src/Configuration/DiactorosConfiguration.php) - Use [Diactoros](https://github.com/zendframework/zend-diactoros/) for the framework [PSR-7](http://www.php-fig.org/psr/psr-7/) implementation
-* [`PayloadConfiguration`](https://github.com/equip/equip/blob/master/src/Configuration/PayloadConfiguration.php) - Use the default Equip class as the implementation for [`PayloadInterface`](https://github.com/equip/adr/blob/master/src/PayloadInterface.php)
-* [`RelayConfiguration`](https://github.com/equip/equip/blob/master/src/Configuration/RelayConfiguration.php) - Use [Relay](http://relayphp.com) for the framework middleware dispatcher
-* [`WhoopsConfiguration`](https://github.com/equip/equip/blob/master/src/Configuration/WhoopsConfiguration.php) - Use [Whoops](http://filp.github.io/whoops/) for handling exceptions
+* [`AurynConfiguration`](https://github.com/equip/framework/blob/master/src/Configuration/AurynConfiguration.php) - Use the `Injector` instance as a singleton and to resolve [actions](https://github.com/pmjones/adr#controller-vs-action)
+* [`DiactorosConfiguration`](https://github.com/equip/framework/blob/master/src/Configuration/DiactorosConfiguration.php) - Use [Diactoros](https://github.com/zendframework/zend-diactoros/) for the framework [PSR-7](http://www.php-fig.org/psr/psr-7/) implementation
+* [`PayloadConfiguration`](https://github.com/equip/framework/blob/master/src/Configuration/PayloadConfiguration.php) - Use the default Equip class as the implementation for [`PayloadInterface`](https://github.com/equip/adr/blob/master/src/PayloadInterface.php)
+* [`RelayConfiguration`](https://github.com/equip/framework/blob/master/src/Configuration/RelayConfiguration.php) - Use [Relay](http://relayphp.com) for the framework middleware dispatcher
+* [`WhoopsConfiguration`](https://github.com/equip/framework/blob/master/src/Configuration/WhoopsConfiguration.php) - Use [Whoops](http://filp.github.io/whoops/) for handling exceptions
 
 ### Optional Configurations
 
 The following configurations are available but not used by default:
 
-* [`EnvConfiguration`](https://github.com/equip/equip/blob/master/src/Configuration/EnvConfiguration.php) - Use [Dotenv](https://github.com/josegonzalez/php-dotenv) to populate the content of [`Env`](https://github.com/equip/equip/blob/master/src/Env.php)
-* [`PlatesResponderConfiguration`](https://github.com/equip/equip/blob/master/src/Configuration/PlatesResponderConfiguration.php) - Use [Plates](http://platesphp.com/) as the default [responder](#responders)
+* [`EnvConfiguration`](https://github.com/equip/framework/blob/master/src/Configuration/EnvConfiguration.php) - Use [Dotenv](https://github.com/josegonzalez/php-dotenv) to populate the content of [`Env`](https://github.com/equip/framework/blob/master/src/Env.php)
+* [`PlatesResponderConfiguration`](https://github.com/equip/framework/blob/master/src/Configuration/PlatesResponderConfiguration.php) - Use [Plates](http://platesphp.com/) as the default [responder](#responders)
 
 #### Setting The Env File
 
@@ -133,7 +133,7 @@ Equip\Application::build()
 
 ### Env Configuration
 
-Equip comes with a [`Env`](https://github.com/equip/equip/blob/master/src/Env.php) class that can be used as a configuration store. Populating this value object is typically done with an "env loader" such as [`josegonzalez/dotenv`](https://github.com/josegonzalez/dotenv). Once configured this class can be injected into other configuration to use secrets like database passwords or API access tokens.
+Equip comes with a [`Env`](https://github.com/equip/framework/blob/master/src/Env.php) class that can be used as a configuration store. Populating this value object is typically done with an "env loader" such as [`josegonzalez/dotenv`](https://github.com/josegonzalez/dotenv). Once configured this class can be injected into other configuration to use secrets like database passwords or API access tokens.
 
 The `Env` class is immutable and can used as an array:
 
@@ -191,7 +191,7 @@ Composer creates the `vendor` directory, downloads all project dependencies into
 
 [Configuration](#configuration) was discussed in an earlier section. In addition to the configurations supported by the Equip core, custom configurations specific to your project can also be applied.
 
-First, create one or more classes implementing [`ConfigurationInterface`](https://github.com/equip/equip/blob/master/src/Configuration/ConfigurationInterface.php) to apply configuration appropriate for your project dependencies.
+First, create one or more classes implementing [`ConfigurationInterface`](https://github.com/equip/framework/blob/master/src/Configuration/ConfigurationInterface.php) to apply configuration appropriate for your project dependencies.
 
 ```php
 // src/Configuration/FooConfiguration.php
@@ -227,7 +227,7 @@ Equip\Application::build()
 
 Equip uses [FastRoute](https://github.com/nikic/FastRoute) internally for routing. As such, it uses that library's URI pattern syntax; see [its documentation](https://github.com/nikic/FastRoute#defining-routes) for more details.
 
-The directory maps URIs to the corresponding [domain](https://github.com/pmjones/adr#model-vs-domain) that the should be used. This is implemented in the Equip [`Directory`](https://github.com/equip/equip/blob/master/src/Directory.php) class. Here is an example of what configuring an instance of it could look like:
+The directory maps URIs to the corresponding [domain](https://github.com/pmjones/adr#model-vs-domain) that the should be used. This is implemented in the Equip [`Directory`](https://github.com/equip/framework/blob/master/src/Directory.php) class. Here is an example of what configuring an instance of it could look like:
 
 ```php
 use Acme\Domain;
@@ -250,7 +250,7 @@ Equip\Application::build()
 
 *It is very important to remember that __the `Directory` object is immutable__! You must __always__ return the directory or changes will be lost.*
 
-It is also possible to provide an [`Action`](https://github.com/equip/equip/blob/master/src/Action.php) object instead of a domain class if you want to modify the responder or input class that will be used to handle the action:
+It is also possible to provide an [`Action`](https://github.com/equip/framework/blob/master/src/Action.php) object instead of a domain class if you want to modify the responder or input class that will be used to handle the action:
 
 ```php
 $directory->get('/login', new Equip\Action(
@@ -305,19 +305,19 @@ Equip\Application::build()
 
 [Relay](http://relayphp.com/) is the recommended middleware dispatcher to use with Equip. It [creates instances of middleware classes](http://relayphp.com/#resolvers) and [invokes them](http://relayphp.com/#middleware-logic) in a chain-like fashion. A consequence of this invocation approach is that the order in which middlewares are specified can be important.
 
-For example, in the `setMiddleware()` call shown earlier, the [`ExceptionHandler`](https://github.com/equip/equip/blob/master/src/Handler/ExceptionHandler.php) -- the Equip handler for dealing with exceptions -- is specified fairly early in the class list contained within its constructor. This is to allow exceptions thrown by any subsequent middlewares in the chain to be handled properly.
+For example, in the `setMiddleware()` call shown earlier, the [`ExceptionHandler`](https://github.com/equip/framework/blob/master/src/Handler/ExceptionHandler.php) -- the Equip handler for dealing with exceptions -- is specified fairly early in the class list contained within its constructor. This is to allow exceptions thrown by any subsequent middlewares in the chain to be handled properly.
 
-For a Equip application to handle requests properly it will require some middleware to be defined using the [`Application`](https://github.com/equip/equip/blob/master/src/Application.php) `setMiddleware` method, which accepts an array of middleware classes to be used. It is also possible to provide a `MiddlewareSet` when calling `Application::build()` to be used as the default set.
+For a Equip application to handle requests properly it will require some middleware to be defined using the [`Application`](https://github.com/equip/framework/blob/master/src/Application.php) `setMiddleware` method, which accepts an array of middleware classes to be used. It is also possible to provide a `MiddlewareSet` when calling `Application::build()` to be used as the default set.
 
 #### Default Middleware
 
 The following middlewares are typically used by default, in this order:
 
 * [`Relay\Middleware\ResponseSender`](https://github.com/relayphp/Relay.Middleware/blob/master/src/ResponseSender.php) - Outputs data from the [PSR-7 Response object](https://github.com/php-fig/http-message/blob/master/src/ResponseInterface.php) to be sent back to the client
-* [`Equip\Handler\ExceptionHandler`](https://github.com/equip/equip/blob/master/src/Handler/ExceptionHandler.php) - Handles exceptions thrown by subsequent middlewares and domains by returning an appropriate application-level response
-* [`Equip\Handler\RouteHandler`](https://github.com/equip/equip/blob/master/src/Handler/RouteHandler.php) - Resolves the request route to the corresponding action to execute
-* [`Equip\Handler\ContentHandler`](https://github.com/equip/equip/blob/master/src/Handler/ContentHandler.php) - Parses request bodies encoded in common formats and makes the parsed version available via the `getParsedBody()` method of the [PSR-7 Request object](https://github.com/php-fig/http-message/blob/master/src/ServerRequestInterface.php)
-* [`Equip\Handler\ActionHandler`](https://github.com/equip/equip/blob/master/src/Handler/ActionHandler.php) - Invokes the [domain](https://github.com/pmjones/adr#model-vs-domain) corresponding to the resolved [action](https://github.com/pmjones/adr#controller-vs-action), applies the [responder](https://github.com/pmjones/adr#view-vs-responder) to the resulting payload, and returns the resulting response
+* [`Equip\Handler\ExceptionHandler`](https://github.com/equip/framework/blob/master/src/Handler/ExceptionHandler.php) - Handles exceptions thrown by subsequent middlewares and domains by returning an appropriate application-level response
+* [`Equip\Handler\RouteHandler`](https://github.com/equip/framework/blob/master/src/Handler/RouteHandler.php) - Resolves the request route to the corresponding action to execute
+* [`Equip\Handler\ContentHandler`](https://github.com/equip/framework/blob/master/src/Handler/ContentHandler.php) - Parses request bodies encoded in common formats and makes the parsed version available via the `getParsedBody()` method of the [PSR-7 Request object](https://github.com/php-fig/http-message/blob/master/src/ServerRequestInterface.php)
+* [`Equip\Handler\ActionHandler`](https://github.com/equip/framework/blob/master/src/Handler/ActionHandler.php) - Invokes the [domain](https://github.com/pmjones/adr#model-vs-domain) corresponding to the resolved [action](https://github.com/pmjones/adr#controller-vs-action), applies the [responder](https://github.com/pmjones/adr#view-vs-responder) to the resulting payload, and returns the resulting response
 
 #### Custom Middleware
 
@@ -366,9 +366,9 @@ Equip\Application::build()
 
 The array accepted by `__invoke()` is created internally via the Equip [`Input`](https://github.com/equip/adr/blob/master/src/Input.php) class, which aggregates data from the request in a fashion similar to how PHP itself aggregates request data into the [`$_REQUEST`](http://php.net/manual/en/reserved.variables.request.php) superglobal.
 
-Equip provides a native implementation of [`PayloadInterface`](https://github.com/equip/domain/blob/master/src/PayloadInterface.php) in the form of its [`Payload`](https://github.com/equip/equip/blob/master/src/Payload.php) class. Once the domain class has returned the payload instance, Equip then passes it off to the appropriate [responder](https://github.com/pmjones/adr#view-vs-responder) to be used in constructing the application response.
+Equip provides a native implementation of [`PayloadInterface`](https://github.com/equip/domain/blob/master/src/PayloadInterface.php) in the form of its [`Payload`](https://github.com/equip/framework/blob/master/src/Payload.php) class. Once the domain class has returned the payload instance, Equip then passes it off to the appropriate [responder](https://github.com/pmjones/adr#view-vs-responder) to be used in constructing the application response.
 
-Rather than having the domain class directly instantiate [`Payload`](https://github.com/equip/equip/blob/master/src/Payload.php) or another implementation of [`PayloadInterface`](https://github.com/equip/domain/blob/master/src/PayloadInterface.php), it's recommended that you make domain classes accept an initial payload instance as a constructor parameter, ideally [typehinted](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) against [`PayloadInterface`](https://github.com/equip/domain/blob/master/src/PayloadInterface.php). This allows domains to be unit tested independently of any particular payload implementation.
+Rather than having the domain class directly instantiate [`Payload`](https://github.com/equip/framework/blob/master/src/Payload.php) or another implementation of [`PayloadInterface`](https://github.com/equip/domain/blob/master/src/PayloadInterface.php), it's recommended that you make domain classes accept an initial payload instance as a constructor parameter, ideally [typehinted](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) against [`PayloadInterface`](https://github.com/equip/domain/blob/master/src/PayloadInterface.php). This allows domains to be unit tested independently of any particular payload implementation.
 
 Here's an example of a domain class.
 
@@ -401,7 +401,7 @@ class Foo implements DomainInterface
 
 Note that the constructor of this domain class declares two parameters, a `\PDO` instance and a payload instance. If a request is made for the URI corresponding to this domain class in the [router configuration](#router), Equip will use the [Auryn configuration](#dependency-injection-container) to instantiate the domain class with the dependencies declared in its constructor. Typically, the constructor is used to store references to dependencies in instance properties so as to be able to use them later in `__invoke()`.
 
-Also note that `__invoke()` returns the payload. The core Equip implementation [`Payload`](https://github.com/equip/equip/blob/master/src/Payload.php) provides an immutable implementation of [`PayloadInterface`](https://github.com/equip/adr/blob/master/src/PayloadInterface.php), which also allows for code like this:
+Also note that `__invoke()` returns the payload. The core Equip implementation [`Payload`](https://github.com/equip/framework/blob/master/src/Payload.php) provides an immutable implementation of [`PayloadInterface`](https://github.com/equip/adr/blob/master/src/PayloadInterface.php), which also allows for code like this:
 
 ```php
 return $this->payload
@@ -417,24 +417,24 @@ Equip provides a few native responder implementations.
 
 ### Chained Responder
 
-[`ChainedResponder`](https://github.com/equip/equip/blob/master/src/Responder/ChainedResponder.php) is the default responder which allows multiple responders to be applied to the same response instance. This is intended to allow for [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) in configuring different areas of the response. The `ChainedResponder` extends [`Destrukt\Set`](https://github.com/destruktphp/destrukt/blob/master/src/Set.php).
+[`ChainedResponder`](https://github.com/equip/framework/blob/master/src/Responder/ChainedResponder.php) is the default responder which allows multiple responders to be applied to the same response instance. This is intended to allow for [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) in configuring different areas of the response. The `ChainedResponder` extends [`Destrukt\Set`](https://github.com/destruktphp/destrukt/blob/master/src/Set.php).
 
-By default [`ChainedResponder`](https://github.com/equip/equip/blob/master/src/Responder/ChainedResponder.php) includes [all the default responders](https://github.com/equip/equip/blob/master/src/Responder). Responders can be added using its `withValue()` method or overwritten entirely using its `withData()` method.
+By default [`ChainedResponder`](https://github.com/equip/framework/blob/master/src/Responder/ChainedResponder.php) includes [all the default responders](https://github.com/equip/framework/blob/master/src/Responder). Responders can be added using its `withValue()` method or overwritten entirely using its `withData()` method.
 
 ### Formatted Responder
 
-[`FormattedResponder`](https://github.com/equip/equip/blob/master/src/Responder/FormattedResponder.php) uses the [Negotiation](https://github.com/willdurand/negotiation) library to support [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation). When a desirable format has been founded, it uses an appropriate implementation of [`AbstractFormatter`](https://github.com/equip/equip/blob/master/src/Formatter/AbstractFormatter.php) to encode the payload data and return it as a string. The `FormattedResponder` extends [`Destrukt\Dictionary`](https://github.com/destruktphp/destrukt/blob/master/src/Dictionary.php).
+[`FormattedResponder`](https://github.com/equip/framework/blob/master/src/Responder/FormattedResponder.php) uses the [Negotiation](https://github.com/willdurand/negotiation) library to support [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation). When a desirable format has been founded, it uses an appropriate implementation of [`AbstractFormatter`](https://github.com/equip/framework/blob/master/src/Formatter/AbstractFormatter.php) to encode the payload data and return it as a string. The `FormattedResponder` extends [`Destrukt\Dictionary`](https://github.com/destruktphp/destrukt/blob/master/src/Dictionary.php).
 
 Here are the formatter implementations that are natively supported:
 
-* [`JsonFormatter`](https://github.com/equip/equip/blob/master/src/Formatter/JsonFormatter.php) - Encodes the payload as [JSON](http://www.json.org/)
-* [`PlatesFormatter`](https://github.com/equip/equip/blob/master/src/Formatter/PlatesFormatter.php) - Applies the payload data to a [Plates](http://platesphp.com/) template specified in the payload and returns the result
+* [`JsonFormatter`](https://github.com/equip/framework/blob/master/src/Formatter/JsonFormatter.php) - Encodes the payload as [JSON](http://www.json.org/)
+* [`PlatesFormatter`](https://github.com/equip/framework/blob/master/src/Formatter/PlatesFormatter.php) - Applies the payload data to a [Plates](http://platesphp.com/) template specified in the payload and returns the result
 
-By default [`FormattedResponder`](https://github.com/equip/equip/blob/master/src/Responder/FormattedResponder.php) includes `JsonFormatter`. Responders can be added using its `withValue()` method or overwritten entirely using its `withData()` method.
+By default [`FormattedResponder`](https://github.com/equip/framework/blob/master/src/Responder/FormattedResponder.php) includes `JsonFormatter`. Responders can be added using its `withValue()` method or overwritten entirely using its `withData()` method.
 
 ### Redirect
 
-[`RedirectResponder`](https://github.com/equip/equip/blob/master/src/Responder/RedirectResponder.php) allows a redirection to be embedded in the payload. In order to activate it requires a `redirect` message to be attached to the [`PayloadInterface`](https://github.com/equip/adr/blob/master/src/PayloadInterface.php). Optionally the `status` can be set when a [`302 Found`](https://en.wikipedia.org/wiki/HTTP_302) is not the correct response.
+[`RedirectResponder`](https://github.com/equip/framework/blob/master/src/Responder/RedirectResponder.php) allows a redirection to be embedded in the payload. In order to activate it requires a `redirect` message to be attached to the [`PayloadInterface`](https://github.com/equip/adr/blob/master/src/PayloadInterface.php). Optionally the `status` can be set when a [`302 Found`](https://en.wikipedia.org/wiki/HTTP_302) is not the correct response.
 
 Modifying the payload to trigger a redirect is very easy:
 
@@ -453,11 +453,11 @@ return $payload->withMessages([
 
 ### Default Setup
 
-Actions, responders, and formatters work together to generate a response. By default `Action` instances created by [routing](#routing) use [`ChainedResponder`](https://github.com/equip/equip/blob/master/src/Responder/ChainedResponder.php) as the responder. By using a custom action you can change the responder for that action. By default the [`ChainedResponder`](https://github.com/equip/equip/blob/master/src/Responder/ChainedResponder.php) includes the [`FormattedResponder`](https://github.com/equip/equip/blob/master/src/Responder/FormattedResponder.php) which delegates formatting to [`JsonFormatter`](https://github.com/equip/equip/blob/master/src/Formatter/JsonFormatter.php).
+Actions, responders, and formatters work together to generate a response. By default `Action` instances created by [routing](#routing) use [`ChainedResponder`](https://github.com/equip/framework/blob/master/src/Responder/ChainedResponder.php) as the responder. By using a custom action you can change the responder for that action. By default the [`ChainedResponder`](https://github.com/equip/framework/blob/master/src/Responder/ChainedResponder.php) includes the [`FormattedResponder`](https://github.com/equip/framework/blob/master/src/Responder/FormattedResponder.php) which delegates formatting to [`JsonFormatter`](https://github.com/equip/framework/blob/master/src/Formatter/JsonFormatter.php).
 
 ### Using Plates
 
-Using [`PlatesFormatter`](https://github.com/equip/equip/blob/master/src/Formatter/PlatesFormatter.php) requires changing the formatters used by [`FormattedResponder`](https://github.com/equip/equip/blob/master/src/Responder/FormattedResponder.php). The easiest way to do this is by using the `PlatesResponderConfiguration` as in the example below:
+Using [`PlatesFormatter`](https://github.com/equip/framework/blob/master/src/Formatter/PlatesFormatter.php) requires changing the formatters used by [`FormattedResponder`](https://github.com/equip/framework/blob/master/src/Responder/FormattedResponder.php). The easiest way to do this is by using the `PlatesResponderConfiguration` as in the example below:
 
 ```php
 Equip\Application::build()


### PR DESCRIPTION
`equip/equip` should be `equip/framework`.

Once this is merged, a [new build](https://readthedocs.org/projects/equipframework/) should be run manually to fix the links assuming that automated integration has not already been configured.

/cc @shadowhand 