### PR TITLE
Ensure ordering of formatters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "require": {
         "php": ">=5.5",
         "arbiter/arbiter": "^0.1",
-        "destrukt/destrukt": "^0.7.1",
+        "destrukt/destrukt": "^0.8.1",
+        "equip/adr": "^1.0",
         "filp/whoops": "^1.1",
         "nikic/fast-route": "^0.7",
         "rdlowrey/auryn": "^1.1",
         "relay/relay": "^1.1",
         "relay/middleware": "^0.1",
-        "equip/adr": "^1.0",
         "willdurand/negotiation": "^2.0",
         "zendframework/zend-diactoros": "^1.0.4"
     },

--- a/src/Responder/FormattedResponder.php
+++ b/src/Responder/FormattedResponder.php
@@ -2,7 +2,7 @@
 
 namespace Equip\Responder;
 
-use Destrukt\Dictionary;
+use Destrukt\SortedDictionary;
 use Negotiation\Negotiator;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -14,9 +14,14 @@ use Equip\Formatter\JsonFormatter;
 use Equip\Resolver\ResolverTrait;
 use Relay\ResolverInterface;
 
-class FormattedResponder extends Dictionary implements ResponderInterface
+class FormattedResponder extends SortedDictionary implements ResponderInterface
 {
     use ResolverTrait;
+
+    /**
+     * @var callable
+     */
+    protected $sorter = 'arsort';
 
     /**
      * @var Negotiator

--- a/tests/Responder/FormattedResponderTest.php
+++ b/tests/Responder/FormattedResponderTest.php
@@ -2,14 +2,15 @@
 
 namespace EquipTests\Responder;
 
+use Equip\Configuration\AurynConfiguration;
+use Equip\Formatter\AbstractFormatter;
+use Equip\Formatter\JsonFormatter;
+use Equip\Payload;
+use Equip\Responder\FormattedResponder;
+use EquipTests\Configuration\ConfigurationTestCase;
 use Negotiation\Negotiator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Equip\Configuration\AurynConfiguration;
-use Equip\Payload;
-use Equip\Responder\FormattedResponder;
-use Equip\Formatter\JsonFormatter;
-use EquipTests\Configuration\ConfigurationTestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 
@@ -51,6 +52,31 @@ class FormattedResponderTest extends ConfigurationTestCase
 
         $formatters = $this->responder->withData($formatters)->toArray();
         $sortedcopy = $formatters;
+    }
+
+    public function testSorting()
+    {
+        $a = $this->getMockBuilder(AbstractFormatter::class)
+            ->setMockClassName('FooFormatter')
+            ->getMockForAbstractClass();
+
+        $b = $this->getMockBuilder(AbstractFormatter::class)
+            ->setMockClassName('BarFormatter')
+            ->getMockForAbstractClass();
+
+        $values = [
+            get_class($a) => 0.5,
+            get_class($b) => 1.0,
+        ];
+
+        $responder = $this->responder->withData($values);
+        $formatters = $responder->toArray();
+
+        $this->assertNotSame($values, $formatters);
+
+        arsort($values);
+
+        $this->assertSame($values, $formatters);
     }
 
     /**


### PR DESCRIPTION
The formatted responder should keep the formatters in order of
preference, not just in order of addition. By switching to a sorted
dictionary the order will always be correct.