### PR TITLE
Improve JsonContentHandler regex matching

### DIFF
--- a/src/Handler/JsonContentHandler.php
+++ b/src/Handler/JsonContentHandler.php
@@ -10,7 +10,7 @@ class JsonContentHandler extends ContentHandler
      */
     protected function isApplicableMimeType($mime)
     {
-        return preg_match('~^application/([a-z.]+\+)?json$~', $mime);
+        return preg_match('~^application/([a-z.]+\+)?json($|;)~', $mime);
     }
 
     /**


### PR DESCRIPTION
Original regex did not match valid json content type header:
"application/json; charset=UTF-8"