### PR TITLE
Move exception logging further up in execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 _..._
 
+## 1.8.1 - 2016-04-29
+
+- Small bugfix to ensure exceptions are logged correctly in `ExceptionHandler`
+
 ## 1.8.0 - 2016-04-28
 
 - Add optional support for `LoggerInterface` to log exceptions caught by `ExceptionHandler`

--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -2,7 +2,6 @@
 
 namespace Equip\Handler;
 
-use Auryn\InjectionException;
 use Equip\Exception\HttpException;
 use Exception;
 use InvalidArgumentException;
@@ -76,6 +75,12 @@ class ExceptionHandler
         try {
             return $next($request, $response);
         } catch (Exception $e) {
+            if ($this->logger) {
+                $this->logger->error($e->getMessage(), [
+                    'exception' => $e
+                ]);
+            }
+
             $type = $this->type($request);
 
             $response = $response->withHeader('Content-Type', $type);
@@ -103,12 +108,6 @@ class ExceptionHandler
             $response->getBody()->write($body);
 
             $this->whoops->popHandler();
-
-            if ($this->logger) {
-                $this->logger->error($e->getMessage(), [
-                    'exception' => $e
-                ]);
-            }
 
             return $response;
         }


### PR DESCRIPTION
Whoops's handleException method was halting execution, which meant
that the logging method was never reached.