### PR TITLE
Update ReadTheDocs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Attempts to be [PSR-1](http://www.php-fig.org/psr/psr-1/),
 [PSR-7](http://www.php-fig.org/psr/psr-7/) compliant. Also uses the
 [ADR](https://github.com/pmjones/adr) pattern. You should too!
 
-To get started, check out [the documentation](http://equipframework.readthedocs.org).
+To get started, check out [the documentation](https://equipframework.readthedocs.io).
 There's also a [sample project](https://github.com/equip/project) that shows
 the best way to use this framework and is a quick way to start a new project.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -4,7 +4,7 @@
 
 ## Authentication Handler
 
-[`AuthHandler`](https://github.com/equip/auth/blob/master/src/AuthHandler.php) is the middleware class that coordinates the authentication process. See Equip documentation for how to [add middleware](http://equipframework.readthedocs.org/en/latest/#middleware) to an application.
+[`AuthHandler`](https://github.com/equip/auth/blob/master/src/AuthHandler.php) is the middleware class that coordinates the authentication process. See Equip documentation for how to [add middleware](/en/latest/#middleware) to an application.
 
 The constructor for [`AuthHandler`](https://github.com/equip/auth/blob/master/src/AuthHandler.php) takes four parameters, which are discussed in the next few sections and should be configured in the [injector](index.md#dependency-injection-container).
 
@@ -57,7 +57,7 @@ $injector->alias(
 );
 ```
 
-**NOTE**: When using `BodyExtractor` it is expected that any [`*ContentHandler` middleware](http://equipframework.readthedocs.org/en/latest/#middleware) will be placed *before* `AuthHandler` to ensure that the request body has been parsed before authentication is attempted.
+**NOTE**: When using `BodyExtractor` it is expected that any [`*ContentHandler` middleware](/en/latest/#middleware) will be placed *before* `AuthHandler` to ensure that the request body has been parsed before authentication is attempted.
 
 ## Adapter
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -81,7 +81,7 @@ class FizzbuzzCommand extends AbstractCommand
 }
 ```
 
-Command classes are tended to be injected (using [Auryn](http://equipframework.readthedocs.org/en/latest/#dependencies)) into and receive options from other classes. Here's an example of a domain class that does this.
+Command classes are tended to be injected (using [Auryn](/en/latest/#dependencies)) into and receive options from other classes. Here's an example of a domain class that does this.
 
 ```php
 use Equip\Adr\DomainInterface;

--- a/docs/session.md
+++ b/docs/session.md
@@ -6,7 +6,7 @@ The benefit of using session objects instead of a global variable is primarily i
 
 ## Configuration
 
-To use the [native session](https://github.com/equip/session/blob/master/src/NativeSession.php) implementation the [configuration](https://github.com/equip/session/blob/master/src/Configuration/SessionConfiguration.php) must be enabled in the [application bootstrap](https://equipframework.readthedocs.org/en/latest/#bootstrap):
+To use the [native session](https://github.com/equip/session/blob/master/src/NativeSession.php) implementation the [configuration](https://github.com/equip/session/blob/master/src/Configuration/SessionConfiguration.php) must be enabled in the [application bootstrap](/en/latest/#bootstrap):
 
 ```php
 Equip\Application::build()


### PR DESCRIPTION
ReadTheDocs has changed from .org to .io for hosted documentation.