### PR TITLE
[WIP] Remove unnecessary Arbiter dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": ">=5.5",
-        "arbiter/arbiter": "^0.1",
         "equip/adr": "^1.3",
         "equip/structure": "^1.0",
         "filp/whoops": "^2.0",

--- a/src/Action.php
+++ b/src/Action.php
@@ -2,12 +2,31 @@
 
 namespace Equip;
 
-use Arbiter\Action as Arbiter;
+use Equip\Input;
+use Equip\Responder\ChainedResponder;
 
-class Action extends Arbiter
+class Action
 {
-    protected $input = 'Equip\Input';
-    protected $responder = 'Equip\Responder\ChainedResponder';
+    /**
+     * The domain specification.
+     *
+     * @var DomainInterface
+     */
+    protected $domain;
+
+    /**
+     * The responder specification.
+     *
+     * @var ResponderInterface
+     */
+    protected $responder = ChainedResponder::class;
+
+    /**
+     * The input specification.
+     *
+     * @var InputInterface
+     */
+    protected $input = Input::class;
 
     /**
      * @inheritDoc
@@ -26,5 +45,35 @@ class Action extends Arbiter
         if ($input) {
             $this->input = $input;
         }
+    }
+
+    /**
+     * Returns the domain specification.
+     *
+     * @return DomainInterface
+     */
+    public function getDomain()
+    {
+        return $this->domain;
+    }
+
+    /**
+     * Returns the responder specification.
+     *
+     * @return ResponderInterface
+     */
+    public function getResponder()
+    {
+        return $this->responder;
+    }
+
+    /**
+     * Returns the input specification.
+     *
+     * @return InputInterface
+     */
+    public function getInput()
+    {
+        return $this->input;
     }
 }

--- a/src/Handler/ActionHandler.php
+++ b/src/Handler/ActionHandler.php
@@ -2,7 +2,6 @@
 
 namespace Equip\Handler;
 
-use Arbiter\Action;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Relay\ResolverInterface;
@@ -10,6 +9,7 @@ use Equip\Adr\PayloadInterface;
 use Equip\Adr\DomainInterface;
 use Equip\Adr\InputInterface;
 use Equip\Adr\ResponderInterface;
+use Equip\Action;
 
 class ActionHandler
 {

--- a/tests/Handler/ActionHandlerTest.php
+++ b/tests/Handler/ActionHandlerTest.php
@@ -2,7 +2,6 @@
 namespace EquipTests\Handler;
 
 use Equip\Action;
-use Equip\Configuration\ArbiterConfiguration;
 use Equip\Configuration\AurynConfiguration;
 use Equip\Handler\ActionHandler;
 use EquipTests\Configuration\ConfigurationTestCase;


### PR DESCRIPTION
Equip uses from there only three getters for Action. Then..

Implement getters.
Add comments.
Add class name as scaler from `::class` keyword.

The `::class` pseudo-constant is resolved at compile-time, and not at runtime. It's a keyword, so does not necessarily depend on the existence of the referenced class.

We can also define properties as private, and to declare this class as final.

@shadowhand what do you think about this?
