### PR TITLE
Use ::class to retrieve the full qualified class name as a string

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -4,7 +4,9 @@ namespace Equip;
 
 use Auryn\Injector;
 use Equip\Configuration\ConfigurationSet;
+use Equip\Directory;
 use Equip\Middleware\MiddlewareSet;
+use Relay\Relay;
 
 class Application
 {
@@ -106,13 +108,13 @@ class Application
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function run($runner = 'Relay\Relay')
+    public function run($runner = Relay::class)
     {
         $this->configuration->apply($this->injector);
 
         return $this->injector
             ->share($this->middleware)
-            ->prepare('Equip\Directory', $this->routing)
+            ->prepare(Directory::class, $this->routing)
             ->execute($runner);
     }
 }

--- a/src/Configuration/AurynConfiguration.php
+++ b/src/Configuration/AurynConfiguration.php
@@ -3,6 +3,8 @@
 namespace Equip\Configuration;
 
 use Auryn\Injector;
+use Equip\Resolver\AurynResolver;
+use Relay\ResolverInterface;
 
 class AurynConfiguration implements ConfigurationInterface
 {
@@ -12,11 +14,11 @@ class AurynConfiguration implements ConfigurationInterface
     public function apply(Injector $injector)
     {
         $injector->alias(
-            'Relay\ResolverInterface',
-            'Equip\Resolver\AurynResolver'
+            ResolverInterface::class,
+            AurynResolver::class
         );
 
-        $injector->define('Equip\Resolver\AurynResolver', [
+        $injector->define(AurynResolver::class, [
             ':injector' => $injector,
         ]);
     }

--- a/src/Configuration/DiactorosConfiguration.php
+++ b/src/Configuration/DiactorosConfiguration.php
@@ -3,6 +3,12 @@
 namespace Equip\Configuration;
 
 use Auryn\Injector;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\ServerRequestFactory;
 
 class DiactorosConfiguration implements ConfigurationInterface
 {
@@ -12,28 +18,28 @@ class DiactorosConfiguration implements ConfigurationInterface
     public function apply(Injector $injector)
     {
         $injector->alias(
-            'Psr\Http\Message\RequestInterface',
+            RequestInterface::class,
             // It should not be necessary to force all requests to be server
             // requests, except that Relay uses the wrong type hint:
             // https://github.com/relayphp/Relay.Relay/issues/25
             //
             // 'Zend\Diactoros\Request'
-            'Zend\Diactoros\ServerRequest'
+            ServerRequest::class
         );
 
         $injector->alias(
-            'Psr\Http\Message\ResponseInterface',
-            'Zend\Diactoros\Response'
+            ResponseInterface::class,
+            Response::class
         );
 
         $injector->alias(
-            'Psr\Http\Message\ServerRequestInterface',
-            'Zend\Diactoros\ServerRequest'
+            ServerRequestInterface::class,
+            ServerRequest::class
         );
 
         $injector->delegate(
-            'Zend\Diactoros\ServerRequest',
-            'Zend\Diactoros\ServerRequestFactory::fromGlobals'
+            ServerRequest::class,
+            [ServerRequestFactory::class, 'fromGlobals']
         );
     }
 }

--- a/src/Configuration/PayloadConfiguration.php
+++ b/src/Configuration/PayloadConfiguration.php
@@ -3,6 +3,8 @@
 namespace Equip\Configuration;
 
 use Auryn\Injector;
+use Equip\Adr\PayloadInterface;
+use Equip\Payload;
 
 class PayloadConfiguration implements ConfigurationInterface
 {
@@ -12,8 +14,8 @@ class PayloadConfiguration implements ConfigurationInterface
     public function apply(Injector $injector)
     {
         $injector->alias(
-            'Equip\Adr\PayloadInterface',
-            'Equip\Payload'
+            PayloadInterface::class,
+            Payload::class
         );
     }
 }

--- a/src/Configuration/RelayConfiguration.php
+++ b/src/Configuration/RelayConfiguration.php
@@ -4,7 +4,9 @@ namespace Equip\Configuration;
 
 use Auryn\Injector;
 use Equip\Middleware\MiddlewareSet;
+use Relay\Relay;
 use Relay\RelayBuilder;
+use Relay\ResolverInterface;
 
 class RelayConfiguration implements ConfigurationInterface
 {
@@ -14,13 +16,13 @@ class RelayConfiguration implements ConfigurationInterface
     public function apply(Injector $injector)
     {
         $injector->define(RelayBuilder::class, [
-            'resolver' => 'Relay\ResolverInterface',
+            'resolver' => ResolverInterface::class
         ]);
 
         $factory = function (RelayBuilder $builder, MiddlewareSet $queue) {
             return $builder->newInstance($queue);
         };
 
-        $injector->delegate('Relay\Relay', $factory);
+        $injector->delegate(Relay::class, $factory);
     }
 }

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -6,6 +6,8 @@ use Equip\Action;
 use Equip\Adr\DomainInterface;
 use Equip\Adr\InputInterface;
 use Equip\Adr\ResponderInterface;
+use Equip\Input;
+use Equip\Responder\ChainedResponder;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class ActionTest extends TestCase
@@ -16,8 +18,8 @@ class ActionTest extends TestCase
         $action = new Action($domain);
 
         $this->assertSame($domain, $action->getDomain());
-        $this->assertSame('Equip\Input', $action->getInput());
-        $this->assertSame('Equip\Responder\ChainedResponder', $action->getResponder());
+        $this->assertSame(Input::class, $action->getInput());
+        $this->assertSame(ChainedResponder::class, $action->getResponder());
 
         $responder = get_class($this->getMock(ResponderInterface::class));
         $action = new Action($domain, $responder);
@@ -28,6 +30,6 @@ class ActionTest extends TestCase
         $action = new Action($domain, null, $input);
 
         $this->assertSame($input, $action->getInput());
-        $this->assertSame('Equip\Responder\ChainedResponder', $action->getResponder());
+        $this->assertSame(ChainedResponder::class, $action->getResponder());
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -6,10 +6,12 @@ use Auryn\Injector;
 use Equip\Application;
 use Equip\Configuration\ConfigurationInterface;
 use Equip\Configuration\ConfigurationSet;
+use Equip\Directory;
 use Equip\Middleware\MiddlewareSet;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionObject;
 use Relay\MiddlewareInterface;
+use Relay\Relay;
 
 class ApplicationTest extends TestCase
 {
@@ -144,13 +146,13 @@ class ApplicationTest extends TestCase
         $injector
             ->expects($this->once())
             ->method('prepare')
-            ->with('Equip\Directory', $routing)
+            ->with(Directory::class, $routing)
             ->willReturnSelf();
 
         $injector
             ->expects($this->once())
             ->method('execute')
-            ->with('Relay\Relay');
+            ->with(Relay::class);
 
         $app = Application::build($injector, null, $middleware);
         $app->setConfiguration([get_class($config1), $config2]);

--- a/tests/Configuration/DiactorosConfigurationTest.php
+++ b/tests/Configuration/DiactorosConfigurationTest.php
@@ -6,13 +6,15 @@ use Equip\Configuration\DiactorosConfiguration;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
 
 class DiactorosConfigurationTest extends ConfigurationTestCase
 {
     protected function getConfigurations()
     {
         return [
-            new DiactorosConfiguration,
+            new DiactorosConfiguration
         ];
     }
 
@@ -20,9 +22,9 @@ class DiactorosConfigurationTest extends ConfigurationTestCase
     {
         return [
             // https://github.com/relayphp/Relay.Relay/issues/25
-            [RequestInterface::class, 'Zend\Diactoros\ServerRequest'],
-            [ResponseInterface::class, 'Zend\Diactoros\Response'],
-            [ServerRequestInterface::class, 'Zend\Diactoros\ServerRequest'],
+            [RequestInterface::class, ServerRequest::class],
+            [ResponseInterface::class, Response::class],
+            [ServerRequestInterface::class, ServerRequest::class]
         ];
     }
 

--- a/tests/Configuration/EnvConfigurationTest.php
+++ b/tests/Configuration/EnvConfigurationTest.php
@@ -4,6 +4,7 @@ namespace EquipTests\Configuration;
 
 use Equip\Configuration\EnvConfiguration;
 use Equip\Env;
+use josegonzalez\Dotenv\Loader;
 
 class EnvConfigurationTest extends ConfigurationTestCase
 {
@@ -14,7 +15,7 @@ class EnvConfigurationTest extends ConfigurationTestCase
 
     public function setUp()
     {
-        if (!class_exists('josegonzalez\Dotenv\Loader')) {
+        if (!class_exists(Loader::class)) {
             $this->markTestSkipped('Dotenv is not installed');
         }
 

--- a/tests/Configuration/PlatesResponderConfigurationTest.php
+++ b/tests/Configuration/PlatesResponderConfigurationTest.php
@@ -6,12 +6,13 @@ use Equip\Configuration\AurynConfiguration;
 use Equip\Configuration\PlatesResponderConfiguration;
 use Equip\Formatter\PlatesFormatter;
 use Equip\Responder\FormattedResponder;
+use League\Plates\Engine;
 
 class PlatesResponderConfigurationTest extends ConfigurationTestCase
 {
     protected function getConfigurations()
     {
-        if (!class_exists('League\Plates\Engine')) {
+        if (!class_exists(Engine::class)) {
             $this->markTestSkipped('Plates is not installed');
         }
 

--- a/tests/DirectoryTest.php
+++ b/tests/DirectoryTest.php
@@ -5,6 +5,7 @@ namespace EquipTests;
 use Equip\Adr\DomainInterface;
 use Equip\Directory;
 use Equip\Input;
+use Equip\Structure\Dictionary;
 
 class DirectoryTest extends DirectoryTestCase
 {
@@ -20,7 +21,7 @@ class DirectoryTest extends DirectoryTestCase
 
     public function testDictionary()
     {
-        $this->assertInstanceOf('Equip\Structure\Dictionary', $this->directory);
+        $this->assertInstanceOf(Dictionary::class, $this->directory);
     }
 
     /**

--- a/tests/DirectoryTestCase.php
+++ b/tests/DirectoryTestCase.php
@@ -2,6 +2,7 @@
 
 namespace EquipTests;
 
+use Equip\Action;
 use Equip\Adr\DomainInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -23,7 +24,7 @@ abstract class DirectoryTestCase extends TestCase
             $domain = get_class($this->getMockDomain());
         }
 
-        $action = $this->getMockBuilder('Equip\Action');
+        $action = $this->getMockBuilder(Action::class);
 
         $action->setConstructorArgs([
             $domain,
@@ -39,6 +40,6 @@ abstract class DirectoryTestCase extends TestCase
      */
     protected function getMockDomain()
     {
-        return $this->getMock('Equip\Adr\DomainInterface');
+        return $this->getMock(DomainInterface::class);
     }
 }

--- a/tests/Responder/RedirectResponderTest.php
+++ b/tests/Responder/RedirectResponderTest.php
@@ -5,6 +5,8 @@ namespace EquipTests\Responder;
 use Equip\Payload;
 use Equip\Responder\RedirectResponder;
 use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response;
 
 class RedirectResponderTest extends TestCase
@@ -26,12 +28,12 @@ class RedirectResponderTest extends TestCase
             'redirect' => '/',
         ]);
 
-        $request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
         $response = new Response;
 
         $response = call_user_func($this->responder, $request, $response, $payload);
 
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('/', $response->getHeaderLine('Location'));
 
@@ -49,8 +51,8 @@ class RedirectResponderTest extends TestCase
     public function testEmptyPayload()
     {
         $payload = new Payload;
-        $request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
-        $response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $returned = call_user_func($this->responder, $request, $response, $payload);
         $this->assertSame($returned, $response);
     }


### PR DESCRIPTION
The `::class` pseudo-constant is resolved at compile-time, and not at runtime. It's a keyword, so does not necessarily depend on the existence of the referenced class. 

This feature [was accepted](https://wiki.php.net/rfc/class_name_scalars) and [implemented in PHP 5.5](https://github.com/php/php-src/pull/187/files).