### PR TITLE
Fixed bad method name in auth docs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -129,7 +129,7 @@ class MyAdapter implements Adapter
 
     public function validateToken($token)
     {
-        $parsed = $this->parser->parse((string) $token);
+        $parsed = $this->parser->parseToken((string) $token);
 
         // $parsed is an instance of \Equip\Auth\Token. You can call its
         // getMetadata() method here to get all metadata associated with the


### PR DESCRIPTION
The method name in [ParserInterface](https://github.com/equip/auth/blob/master/src/Jwt/ParserInterface.php#L15) is ```parseToken()``` not ```parse()```.