### PR TITLE
[adr 2.0] Implementation of setting methods

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Equip;
 
 use Equip\Adr\PayloadInterface;
@@ -24,6 +25,11 @@ class Payload implements PayloadInterface
      * @var array
      */
     private $messages;
+
+    /**
+     * @var array
+     */
+    private $settings;
 
     /**
      * @inheritDoc
@@ -60,7 +66,7 @@ class Payload implements PayloadInterface
      */
     public function getInput()
     {
-        return $this->input;
+        return (array) $this->input;
     }
 
     /**
@@ -79,7 +85,7 @@ class Payload implements PayloadInterface
      */
     public function getOutput()
     {
-        return $this->output;
+        return (array) $this->output;
     }
 
     /**
@@ -98,6 +104,50 @@ class Payload implements PayloadInterface
      */
     public function getMessages()
     {
-        return $this->messages;
+        return (array) $this->messages;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withSetting($name, $value)
+    {
+        $copy = clone $this;
+        $copy->settings[$name] = $value;
+
+        return $copy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withoutSetting($name)
+    {
+        $copy = clone $this;
+        unset($copy->settings[$name]);
+
+        return $copy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSetting($name)
+    {
+        $key = array_key_exists($name, (array) $this->settings);
+
+        if ($key === false) {
+            return false;
+        }
+
+        return $this->settings[$name];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSettings()
+    {
+        return (array) $this->settings;
     }
 }

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -134,13 +134,11 @@ class Payload implements PayloadInterface
      */
     public function getSetting($name)
     {
-        $key = array_key_exists($name, (array) $this->settings);
-
-        if ($key === false) {
-            return false;
+        if (isset($this->settings[$name])) {
+            return $this->settings[$name];
         }
 
-        return $this->settings[$name];
+        return null;
     }
 
     /**

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -14,22 +14,22 @@ class Payload implements PayloadInterface
     /**
      * @var array
      */
-    private $input;
+    private $input = [];
 
     /**
      * @var array
      */
-    private $output;
+    private $output = [];
 
     /**
      * @var array
      */
-    private $messages;
+    private $messages = [];
 
     /**
      * @var array
      */
-    private $settings;
+    private $settings = [];
 
     /**
      * @inheritDoc
@@ -66,7 +66,7 @@ class Payload implements PayloadInterface
      */
     public function getInput()
     {
-        return (array) $this->input;
+        return $this->input;
     }
 
     /**
@@ -85,7 +85,7 @@ class Payload implements PayloadInterface
      */
     public function getOutput()
     {
-        return (array) $this->output;
+        return $this->output;
     }
 
     /**
@@ -104,7 +104,7 @@ class Payload implements PayloadInterface
      */
     public function getMessages()
     {
-        return (array) $this->messages;
+        return $this->messages;
     }
 
     /**
@@ -148,6 +148,6 @@ class Payload implements PayloadInterface
      */
     public function getSettings()
     {
-        return (array) $this->settings;
+        return $this->settings;
     }
 }

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -70,7 +70,7 @@ class PayloadTest extends TestCase
 
         $empty = $copy->withoutSetting($name);
 
-        $this->assertFalse($empty->getSetting($name));
+        $this->assertNull($empty->getSetting($name));
         $this->assertEmpty($empty->getSettings());
     }
 }

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -3,28 +3,29 @@
 namespace EquipTests;
 
 use Equip\Payload;
+use PHPUnit_Framework_TestCase as TestCase;
 
-class PayloadTest extends \PHPUnit_Framework_TestCase
+class PayloadTest extends TestCase
 {
     public function testStatus()
     {
         $load = new Payload;
         $copy = $load->withStatus(Payload::STATUS_OK);
 
-        $this->assertNull($load->getStatus());
+        $this->assertEmpty($load->getStatus());
         $this->assertSame(Payload::STATUS_OK, $copy->getStatus());
     }
 
     public function testInput()
     {
         $input = [
-            'test' => true,
+            'test' => true
         ];
 
         $load = new Payload;
         $copy = $load->withInput($input);
 
-        $this->assertNull($load->getInput());
+        $this->assertEmpty($load->getInput());
         $this->assertSame($input, $copy->getInput());
     }
 
@@ -32,26 +33,44 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
     {
         $messages = [
             'username' => 'not found',
-            'password' => 'invalid',
+            'password' => 'invalid'
         ];
 
         $load = new Payload;
         $copy = $load->withMessages($messages);
 
-        $this->assertNull($load->getMessages());
+        $this->assertEmpty($load->getMessages());
         $this->assertSame($messages, $copy->getMessages());
     }
 
     public function testOutput()
     {
         $output = [
-            'collection' => [],
+            'collection' => []
         ];
 
         $load = new Payload;
         $copy = $load->withOutput($output);
 
-        $this->assertNull($load->getOutput());
+        $this->assertEmpty($load->getOutput());
         $this->assertSame($output, $copy->getOutput());
+    }
+
+    public function testSettings()
+    {
+        $name = 'template';
+        $value = 'index';
+
+        $load = new Payload;
+        $copy = $load->withSetting($name, $value);
+
+        $this->assertEmpty($load->getSettings());
+        $this->assertSame($value, $copy->getSetting($name));
+        $this->assertSame([$name => $value], $copy->getSettings());
+
+        $empty = $copy->withoutSetting($name);
+
+        $this->assertFalse($empty->getSetting($name));
+        $this->assertEmpty($empty->getSettings());
     }
 }


### PR DESCRIPTION
Implemented with minimal logic. Your opinion?
I noticed that [some getters of Payload interface](https://github.com/equip/adr/blob/8a618e4e4c9b4f6bc43111deec34817a4f324c0e/src/PayloadInterface.php#L55) should return an `array`, but current implementation may return `null` (and the [current tests](https://github.com/equip/framework/blob/e618b83ff90ffcac0fd6b28a915d7119e40efbbb/tests/PayloadTest.php#L54) use `assertNull`), so I would like to clarify.
```php
$payload = new Payload;
var_dump($payload->getOutput()); // null
$payload = $payload->withOutput([]);
var_dump($payload->getOutput()); // array
```
With this need to do something? 
For example, to initialize the variables as empty array or use a typecast in the methods.