### PR TITLE
[adr 2.0] Use Payload::getSetting for PlatesFormatter

### DIFF
--- a/src/Formatter/PlatesFormatter.php
+++ b/src/Formatter/PlatesFormatter.php
@@ -3,15 +3,15 @@
 namespace Equip\Formatter;
 
 use Equip\Adr\PayloadInterface;
+use Equip\Formatter\HtmlFormatter;
 use League\Plates\Engine;
-use League\Plates\Template\Template;
 
 class PlatesFormatter extends HtmlFormatter
 {
     /**
      * @var Engine
      */
-    protected $engine;
+    private $engine;
 
     /**
      * @param Engine $engine
@@ -26,27 +26,19 @@ class PlatesFormatter extends HtmlFormatter
      */
     public function body(PayloadInterface $payload)
     {
-        $template = $this->template($payload);
-        $template = $this->engine->make($template);
-        return $this->render($template, $payload);
+        return $this->render($payload);
     }
 
     /**
      * @param PayloadInterface $payload
+     *
      * @return string
      */
-    protected function template(PayloadInterface $payload)
+    private function render(PayloadInterface $payload)
     {
-        return $payload->getOutput()['template'];
-    }
+        $template = $payload->getSetting('template');
+        $output = $payload->getOutput();
 
-    /**
-     * @param Template $template
-     * @param PayloadInterface $payload
-     * @return string
-     */
-    protected function render(Template $template, PayloadInterface $payload)
-    {
-        return $template->render($payload->getOutput());
+        return $this->engine->render($template, $output);
     }
 }

--- a/tests/Formatter/PlatesFormatterTest.php
+++ b/tests/Formatter/PlatesFormatterTest.php
@@ -2,19 +2,13 @@
 
 namespace EquipTests\Formatter;
 
+use Equip\Adr\PayloadInterface;
 use Equip\Formatter\PlatesFormatter;
-use Equip\Payload;
 use League\Plates\Engine;
-use Lukasoppermann\Httpstatus\Httpstatus;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class PlatesFormatterTest extends TestCase
 {
-    /**
-     * @var Engine
-     */
-    protected $templates;
-
     /**
      * @var PlatesFormatter
      */
@@ -22,14 +16,12 @@ class PlatesFormatterTest extends TestCase
 
     public function setUp()
     {
-        if (!class_exists('League\Plates\Engine')) {
+        if (!class_exists(Engine::class)) {
             $this->markTestSkipped('Plates is not installed');
         }
 
-        $this->templates = new Engine(__DIR__ . '/../_templates');
         $this->formatter = new PlatesFormatter(
-            $this->templates,
-            new HttpStatus
+            new Engine(__DIR__ . '/../_templates')
         );
     }
 
@@ -45,12 +37,22 @@ class PlatesFormatterTest extends TestCase
 
     public function testResponse()
     {
-        $payload = (new Payload)->withOutput([
-                'template' => 'test',
-                'header'   => 'header',
-                'body'     => 'body',
-                'footer'   => 'footer',
-            ]);
+        $template = 'index';
+        $output = [
+            'header' => 'header',
+            'body'   => 'body',
+            'footer' => 'footer'
+        ];
+
+        $payload = $this->getMock(PayloadInterface::class);
+
+        $payload->expects($this->any())
+            ->method('getOutput')
+            ->willReturn($output);
+
+        $payload->expects($this->any())
+            ->method('getSetting')
+            ->willReturn($template);
 
         $body = (string) $this->formatter->body($payload);
 

--- a/tests/Formatter/PlatesFormatterTest.php
+++ b/tests/Formatter/PlatesFormatterTest.php
@@ -37,7 +37,7 @@ class PlatesFormatterTest extends TestCase
 
     public function testResponse()
     {
-        $template = 'index';
+        $template = 'test';
         $output = [
             'header' => 'header',
             'body'   => 'body',
@@ -47,14 +47,14 @@ class PlatesFormatterTest extends TestCase
         $payload = $this->getMock(PayloadInterface::class);
 
         $payload->expects($this->any())
-            ->method('getOutput')
-            ->willReturn($output);
-
-        $payload->expects($this->any())
             ->method('getSetting')
             ->willReturn($template);
 
-        $body = (string) $this->formatter->body($payload);
+        $payload->expects($this->any())
+            ->method('getOutput')
+            ->willReturn($output);
+
+        $body = $this->formatter->body($payload);
 
         $this->assertEquals("<h1>header</h1>\n<p>body</p>\n<span>footer</span>\n", $body);
     }


### PR DESCRIPTION
The tests will fall because [adr 2.0.0-alpha2](https://github.com/equip/adr/releases/tag/2.0.0-alpha2) is not available (yet) on [Packagist](https://packagist.org/packages/equip/adr).

**UPD.** The test was updated. Now everything should be fine.