### PR TITLE
[travis] Remove composer "prefer-stable/lowest" flags from the dev branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,27 @@ php:
   - 7.0
   - hhvm
 
-matrix:
-  include:
-    - php: 5.5
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-
 services:
   - redis-server
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: hhvm
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+sudo: false
+
+git:
+  depth: 1
 
 before_script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travis.php.ini; fi'
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer update --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
In the dev branch [can be used](https://github.com/equip/framework/blob/e618b83ff90ffcac0fd6b28a915d7119e40efbbb/composer.json#L12) dependencies from unstable packages. (like [2.0.0-alpha2](https://github.com/equip/adr/releases/tag/2.0.0-alpha2))

Ref: #48