### PR TITLE
Allow to use an instance (object) of middleware

### DIFF
--- a/src/Resolver/AurynResolver.php
+++ b/src/Resolver/AurynResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Equip\Resolver;
 
 use Auryn\Injector;
@@ -17,14 +18,18 @@ class AurynResolver implements ResolverInterface
     }
 
     /**
-     * Get an instance of the given class
+     * Resolve a class spec into an object, if it is not already instantiated.
      *
-     * @param string $spec Fully-qualified class name
+     * @param string|object $specOrObject
      *
      * @return object
      */
-    public function __invoke($spec)
+    public function __invoke($specOrObject)
     {
-        return $this->injector->make($spec);
+        if (is_object($specOrObject)) {
+            return $specOrObject;
+        }
+
+        return $this->injector->make($specOrObject);
     }
 }

--- a/src/Resolver/ResolverTrait.php
+++ b/src/Resolver/ResolverTrait.php
@@ -10,18 +10,14 @@ trait ResolverTrait
     private $resolver;
 
     /**
-     * Resolve a class spec into an object, if it is not already instantiated.
+     * Resolve a class spec into an object.
      *
-     * @param string|object $specOrObject
+     * @param string $spec Fully-qualified class name
      *
      * @return object
      */
-    private function resolve($specOrObject)
+    private function resolve($spec)
     {
-        if (is_object($specOrObject)) {
-            return $specOrObject;
-        }
-
-        return call_user_func($this->resolver, $specOrObject);
+        return call_user_func($this->resolver, $spec);
     }
 }


### PR DESCRIPTION
This change will allow the use of prepared objects of middleware.

Now [`ResolverTrait::resolve`](https://github.com/equip/framework/blob/b253bd5bf0b4fed4f1c8fe09288904bb16a6b34b/src/Resolver/ResolverTrait.php#L19) method does not check for object and fully trust a conctrete implementation of [`ResolverInterface`](https://github.com/relayphp/Relay.Relay/blob/8268d51e58caa6b95dc8ee9680a2658f6bc288d1/src/ResolverInterface.php). (I hope it will not affect performance) So now any Resolver must return the object back when an instance already exists.

I guess for this case we need to have a test.