### PR TITLE
Use payload settings for redirect responder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ _..._
 ## 2.0.0 - ???
 
 - Update Plates formatter to use Payload settings for template
-- Allow Resolver to work with already instantiated objects
+- Update redirect responder to use Payload settings for target location
+- Allow resolver to work with already instantiated objects
 - Separate response formatting from HTTP status code with `StatusResponder`
 - Replace `AbstractFormatter` with a `FormatterInterface`
 - Remove dependency on Arbiter

--- a/src/Responder/RedirectResponder.php
+++ b/src/Responder/RedirectResponder.php
@@ -17,29 +17,12 @@ class RedirectResponder implements ResponderInterface
         ResponseInterface $response,
         PayloadInterface $payload
     ) {
-        if ($this->hasRedirect($payload)) {
-            $messages = $payload->getMessages() + [
-                'status' => 302,
-            ];
+        $location = $payload->getSetting('redirect');
 
-            return $response
-                ->withStatus($messages['status'])
-                ->withHeader('Location', $messages['redirect']);
+        if (!empty($location)) {
+            $response = $response->withHeader('Location', $location);
         }
 
         return $response;
-    }
-
-    /**
-     * Check if the payload contains a redirect
-     *
-     * @param PayloadInterface $payload
-     *
-     * @return boolean
-     */
-    private function hasRedirect(PayloadInterface $payload)
-    {
-        $messages = $payload->getMessages();
-        return !empty($messages['redirect']);
     }
 }

--- a/tests/Responder/RedirectResponderTest.php
+++ b/tests/Responder/RedirectResponderTest.php
@@ -2,6 +2,7 @@
 
 namespace EquipTests\Responder;
 
+use Equip\Adr\Status;
 use Equip\Payload;
 use Equip\Responder\RedirectResponder;
 use PHPUnit_Framework_TestCase as TestCase;
@@ -23,10 +24,7 @@ class RedirectResponderTest extends TestCase
 
     public function testRedirect()
     {
-        $payload = new Payload;
-        $payload = $payload->withMessages([
-            'redirect' => '/',
-        ]);
+        $payload = (new Payload())->withSetting('redirect', '/');
 
         $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
         $response = new Response;
@@ -34,18 +32,7 @@ class RedirectResponderTest extends TestCase
         $response = call_user_func($this->responder, $request, $response, $payload);
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('/', $response->getHeaderLine('Location'));
-
-        $payload = new Payload;
-        $payload = $payload->withMessages([
-            'status' => 301,
-            'redirect' => '/',
-        ]);
-
-        $response = call_user_func($this->responder, $request, $response, $payload);
-
-        $this->assertEquals(301, $response->getStatusCode());
     }
 
     public function testEmptyPayload()


### PR DESCRIPTION
The redirect location is not meant to be output as part of the response
body, so it makes more sense to use payload settings.

Refs equip/adr#7
Refs #39