### PR TITLE
Remove deprecation notes on content handlers

### DIFF
--- a/src/Handler/ContentHandler.php
+++ b/src/Handler/ContentHandler.php
@@ -4,9 +4,6 @@ namespace Equip\Handler;
 
 use Relay\Middleware\ContentHandler as AbstractHandler;
 
-/**
- * @deprecated 1.4.0 Switched to Relay.Middleware
- */
 abstract class ContentHandler extends AbstractHandler
 {
 }

--- a/src/Handler/FormContentHandler.php
+++ b/src/Handler/FormContentHandler.php
@@ -4,9 +4,6 @@ namespace Equip\Handler;
 
 use Relay\Middleware\FormContentHandler as AbstractHandler;
 
-/**
- * @deprecated 1.4.0 Switched to Relay.Middleware
- */
 class FormContentHandler extends AbstractHandler
 {
 }

--- a/src/Handler/JsonContentHandler.php
+++ b/src/Handler/JsonContentHandler.php
@@ -5,9 +5,6 @@ namespace Equip\Handler;
 use Equip\Exception\HttpException;
 use Relay\Middleware\JsonContentHandler as AbstractHandler;
 
-/**
- * @deprecated 1.4.0 Switched to Relay.Middleware
- */
 class JsonContentHandler extends AbstractHandler
 {
     /**
@@ -16,14 +13,6 @@ class JsonContentHandler extends AbstractHandler
     public function __construct($assoc = true, $maxDepth = 512, $options = 0)
     {
         return parent::__construct($assoc, $maxDepth, $options);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function isApplicableMimeType($mime)
-    {
-        return preg_match('~^application/([a-z.]+\+)?json($|;)~', $mime);
     }
 
     /**

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -30,4 +30,13 @@ class ExceptionTest extends TestCase
 
         $this->assertEquals(implode(',', $allowed), $response->getHeaderLine('Allow'));
     }
+
+    public function testHttpBadRequest()
+    {
+        $exception = HttpException::badRequest('Cannot parse request');
+
+        $this->assertInstanceOf(HttpException::class, $exception);
+        $this->assertEquals(400, $exception->getCode());
+
+    }
 }


### PR DESCRIPTION
While the actual content handling comes straight from Relay, we have
some different requirements, specifically in JSON content handling.
Rather than trying to remove these, which could make upgrades more
difficult, remove the parts that are duplication and un-deprecate the
classes that are compatible. This gives us more flexibility to adjust
to Relay upgrades.

Also add in a missing HTTP exception test.