### PR TITLE
Upgrade PHPUnit version to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,38 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+git:
+  depth: 1
+
+env:
+  global:
+    - PHPUNIT_VERSION="^5.4"
+
 matrix:
   include:
-    - php: 5.5
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: 5.6
+      env:
+        - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
 services:
   - redis-server
 
 before_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travis.php.ini; fi'
+  - bash -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then phpenv config-add .travis.php.ini; fi'
   - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer require phpunit/phpunit:${PHPUNIT_VERSION}
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "josegonzalez/dotenv": "^2.0",
         "league/plates": "^3.1",
         "monolog/monolog": "^1.19",
-        "phpunit/phpunit": "^4.8|^5.0",
         "zendframework/zend-diactoros": "^1.0.4"
     },
     "suggest": {

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -14,19 +14,19 @@ class ActionTest extends TestCase
 {
     public function testInstance()
     {
-        $domain = get_class($this->getMock(DomainInterface::class));
+        $domain = get_class($this->createMock(DomainInterface::class));
         $action = new Action($domain);
 
         $this->assertSame($domain, $action->getDomain());
         $this->assertSame(Input::class, $action->getInput());
         $this->assertSame(ChainedResponder::class, $action->getResponder());
 
-        $responder = get_class($this->getMock(ResponderInterface::class));
+        $responder = get_class($this->createMock(ResponderInterface::class));
         $action = new Action($domain, $responder);
 
         $this->assertSame($responder, $action->getResponder());
 
-        $input = get_class($this->getMock(InputInterface::class));
+        $input = get_class($this->createMock(InputInterface::class));
         $action = new Action($domain, null, $input);
 
         $this->assertSame($input, $action->getInput());

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -48,10 +48,10 @@ class ApplicationTest extends TestCase
 
     public function testCreate()
     {
-        $injector = $this->getMock(Injector::class);
-        $configuration = $this->getMock(ConfigurationSet::class);
-        $middleware = $this->getMock(MiddlewareSet::class);
-        $dispatching = $this->getMock(DispatchingSet::class);
+        $injector = $this->createMock(Injector::class);
+        $configuration = $this->createMock(ConfigurationSet::class);
+        $middleware = $this->createMock(MiddlewareSet::class);
+        $dispatching = $this->createMock(DispatchingSet::class);
 
         $app = new Application($injector, $configuration, $middleware, $dispatching);
 
@@ -61,10 +61,10 @@ class ApplicationTest extends TestCase
     public function testSetConfiguration()
     {
         $data = [
-            $this->getMock(ConfigurationInterface::class),
+            $this->createMock(ConfigurationInterface::class),
         ];
 
-        $configuration = $this->getMock(ConfigurationSet::class);
+        $configuration = $this->createMock(ConfigurationSet::class);
         $configuration
             ->expects($this->once())
             ->method('withValues')
@@ -80,10 +80,10 @@ class ApplicationTest extends TestCase
     public function testSetMiddleware()
     {
         $data = [
-            $this->getMock(MiddlewareInterface::class),
+            $this->createMock(MiddlewareInterface::class),
         ];
 
-        $middleware = $this->getMock(MiddlewareSet::class);
+        $middleware = $this->createMock(MiddlewareSet::class);
         $middleware
             ->expects($this->once())
             ->method('withValues')
@@ -104,7 +104,7 @@ class ApplicationTest extends TestCase
             },
         ];
 
-        $dispatching = $this->getMock(DispatchingSet::class);
+        $dispatching = $this->createMock(DispatchingSet::class);
         $dispatching
             ->expects($this->once())
             ->method('withValues')
@@ -120,11 +120,11 @@ class ApplicationTest extends TestCase
 
     public function testRun()
     {
-        $injector = $this->getMock(Injector::class);
-        $middleware = $this->getMock(MiddlewareSet::class);
-        $dispatching = $this->getMock(DispatchingSet::class);
-        $config1 = $this->getMock(ConfigurationInterface::class);
-        $config2 = $this->getMock(ConfigurationInterface::class);
+        $injector = $this->createMock(Injector::class);
+        $middleware = $this->createMock(MiddlewareSet::class);
+        $dispatching = $this->createMock(DispatchingSet::class);
+        $config1 = $this->createMock(ConfigurationInterface::class);
+        $config2 = $this->createMock(ConfigurationInterface::class);
 
         $config1
             ->expects($this->once())

--- a/tests/Configuration/ConfigurationSetTest.php
+++ b/tests/Configuration/ConfigurationSetTest.php
@@ -11,8 +11,8 @@ class ConfigurationSetTest extends TestCase
 {
     public function testSet()
     {
-        $config = $this->getMock(ConfigurationInterface::class);
-        $injector = $this->getMock(Injector::class);
+        $config = $this->createMock(ConfigurationInterface::class);
+        $injector = $this->createMock(Injector::class);
 
         $injector
             ->expects($this->once())
@@ -34,8 +34,8 @@ class ConfigurationSetTest extends TestCase
 
     public function testSetObject()
     {
-        $config = $this->getMock(ConfigurationInterface::class);
-        $injector = $this->getMock(Injector::class);
+        $config = $this->createMock(ConfigurationInterface::class);
+        $injector = $this->createMock(Injector::class);
 
         $config
             ->expects($this->once())

--- a/tests/Configuration/ConfigurationSetTest.php
+++ b/tests/Configuration/ConfigurationSetTest.php
@@ -5,7 +5,9 @@ namespace EquipTests\Configuration;
 use Auryn\Injector;
 use Equip\Configuration\ConfigurationInterface;
 use Equip\Configuration\ConfigurationSet;
+use Equip\Exception\ConfigurationException;
 use PHPUnit_Framework_TestCase as TestCase;
+use stdClass;
 
 class ConfigurationSetTest extends TestCase
 {
@@ -49,13 +51,13 @@ class ConfigurationSetTest extends TestCase
         $set->apply($injector);
     }
 
-    /**
-     * @expectedException Equip\Exception\ConfigurationException
-     * @expectedExceptionRegExp /class .* must implement ConfigurationInterface/i
-     */
     public function testInvalidClass()
     {
-        $set = new ConfigurationSet;
-        $set = $set->withValue('\stdClass');
+        $this->setExpectedExceptionRegExp(
+            ConfigurationException::class,
+            '/class .* must implement .*ConfigurationInterface/i'
+        );
+
+        (new ConfigurationSet)->withValue(stdClass::class);
     }
 }

--- a/tests/Configuration/EnvConfigurationTest.php
+++ b/tests/Configuration/EnvConfigurationTest.php
@@ -4,6 +4,7 @@ namespace EquipTests\Configuration;
 
 use Equip\Configuration\EnvConfiguration;
 use Equip\Env;
+use Equip\Exception\EnvException;
 use josegonzalez\Dotenv\Loader;
 
 class EnvConfigurationTest extends ConfigurationTestCase
@@ -42,22 +43,24 @@ class EnvConfigurationTest extends ConfigurationTestCase
         $this->destroyEnv();
     }
 
-    /**
-     * @expectedException \Equip\Exception\EnvException
-     * @expectedExceptionMessageRegExp /unable to automatically detect/i
-     */
     public function testUnableToDetect()
     {
-        $config = new EnvConfiguration;
+        $this->setExpectedExceptionRegExp(
+            EnvException::class,
+            '/unable to automatically detect/i'
+        );
+
+        new EnvConfiguration;
     }
 
-    /**
-     * @expectedException \Equip\Exception\EnvException
-     * @expectedExceptionMessageRegExp /environment file .* does not exist/i
-     */
     public function testInvalidRoot()
     {
-        $config = new EnvConfiguration('/tmp/bad/path/.env');
+        $this->setExpectedExceptionRegExp(
+            EnvException::class,
+            '/environment file .* does not exist/i'
+        );
+
+        new EnvConfiguration('/tmp/bad/path/.env');
     }
 
     /**

--- a/tests/Configuration/RedisConfigurationTest.php
+++ b/tests/Configuration/RedisConfigurationTest.php
@@ -12,9 +12,13 @@ class RedisConfigurationTest extends TestCase
 {
     public function testApply()
     {
+        if (!class_exists(Redis::class)) {
+            $this->markTestSkipped('Redis is not installed');
+        }
+
         $injector = new Injector;
         $injector->delegate(Redis::class, function() {
-            $redisMock = $this->getMock(Redis::class, ['connect']);
+            $redisMock = $this->createMock(Redis::class, ['connect']);
 
             $redisMock
                 ->expects($this->once())
@@ -24,7 +28,7 @@ class RedisConfigurationTest extends TestCase
         });
 
         $config = new RedisConfiguration(
-            $this->getMock(Env::class)
+            $this->createMock(Env::class)
         );
         $config->apply($injector);
 

--- a/tests/DirectoryTest.php
+++ b/tests/DirectoryTest.php
@@ -4,6 +4,7 @@ namespace EquipTests;
 
 use Equip\Adr\DomainInterface;
 use Equip\Directory;
+use Equip\Exception\DirectoryException;
 use Equip\Input;
 use Equip\Structure\Dictionary;
 
@@ -24,13 +25,14 @@ class DirectoryTest extends DirectoryTestCase
         $this->assertInstanceOf(Dictionary::class, $this->directory);
     }
 
-    /**
-     * @expectedException \Equip\Exception\DirectoryException
-     * @expectedExceptionRegExp /entry .* is not an action/i
-     */
     public function testInvalidAction()
     {
-        $directory = $this->directory->withValue('GET /', $this);
+        $this->setExpectedExceptionRegExp(
+            DirectoryException::class,
+            '/Directory entry .* is not an .* instance/i'
+        );
+
+        $this->directory->withValue('GET /', $this);
     }
 
     public function testAction()
@@ -39,7 +41,7 @@ class DirectoryTest extends DirectoryTestCase
         $directory = $this->directory->action('LIST', '/', $action);
 
         $this->assertTrue($directory->hasValue('LIST /'));
-        $this->assertSame($action, $directory->getValue("LIST /"));
+        $this->assertSame($action, $directory->getValue('LIST /'));
     }
 
     public function testActionWithDomain()
@@ -75,7 +77,7 @@ class DirectoryTest extends DirectoryTestCase
             ['PATCH'],
             ['HEAD'],
             ['DELETE'],
-            ['OPTIONS']
+            ['OPTIONS'],
         ];
     }
 }

--- a/tests/DirectoryTestCase.php
+++ b/tests/DirectoryTestCase.php
@@ -40,6 +40,6 @@ abstract class DirectoryTestCase extends TestCase
      */
     protected function getMockDomain()
     {
-        return $this->getMock(DomainInterface::class);
+        return $this->createMock(DomainInterface::class);
     }
 }

--- a/tests/Dispatching/DispatchingSetTest.php
+++ b/tests/Dispatching/DispatchingSetTest.php
@@ -42,7 +42,7 @@ class DispatchingSetTest extends TestCase
         $dispatching = new DispatchingSet($dispatchers);
         $directory = new Directory;
 
-        $prepared = $dispatching($directory, $this->getMock(Injector::class));
+        $prepared = $dispatching($directory, $this->createMock(Injector::class));
 
         $this->assertInstanceOf(Directory::class, $prepared);
         $this->assertNotSame($prepared, $directory);

--- a/tests/Formatter/PlatesFormatterTest.php
+++ b/tests/Formatter/PlatesFormatterTest.php
@@ -44,7 +44,7 @@ class PlatesFormatterTest extends TestCase
             'footer' => 'footer'
         ];
 
-        $payload = $this->getMock(PayloadInterface::class);
+        $payload = $this->createMock(PayloadInterface::class);
 
         $payload->expects($this->any())
             ->method('getSetting')

--- a/tests/Handler/DispatchHandlerTest.php
+++ b/tests/Handler/DispatchHandlerTest.php
@@ -4,6 +4,7 @@ namespace EquipTests\Handler;
 
 use EquipTests\DirectoryTestCase;
 use Equip\Directory;
+use Equip\Exception\HttpException;
 use Equip\Handler\ActionHandler;
 use Equip\Handler\DispatchHandler;
 use Zend\Diactoros\Response;
@@ -38,12 +39,13 @@ class DispatchHandlerTest extends DirectoryTestCase
         $this->dispatch($directory, $request, $response, $next);
     }
 
-    /**
-     * @expectedException \Equip\Exception\HttpException
-     * @expectedExceptionRegExp /cannot find any resource at/i
-     */
     public function testNotFoundException()
     {
+        $this->setExpectedExceptionRegExp(
+            HttpException::class,
+            '/cannot find any resource at/i'
+        );
+
         $handler = new DispatchHandler($this->directory);
         $request = $this->getRequest('GET', '/');
         $response = new Response;
@@ -58,12 +60,13 @@ class DispatchHandlerTest extends DirectoryTestCase
         );
     }
 
-    /**
-     * @expectedException \Equip\Exception\HttpException
-     * @expectedExceptionRegExp /cannot access resource .* using method/i
-     */
     public function testMethodNotAllowedException()
     {
+        $this->setExpectedExceptionRegExp(
+            HttpException::class,
+            '/cannot access resource .* using method/i'
+        );
+
         $handler = new DispatchHandler($this->directory);
         $request = $this->getRequest('POST');
         $response = new Response;

--- a/tests/Handler/ExceptionHandlerTest.php
+++ b/tests/Handler/ExceptionHandlerTest.php
@@ -111,7 +111,7 @@ class MockMonologConfiguration extends TestCase implements ConfigurationInterfac
     public function apply(Injector $injector)
     {
         $injector->delegate(LoggerInterface::class, function () {
-            $loggerMock = $this->getMock(LoggerInterface::class);
+            $loggerMock = $this->createMock(LoggerInterface::class);
 
             $loggerMock
                 ->expects($this->atLeastOnce())

--- a/tests/Handler/JsonContentHandlerTest.php
+++ b/tests/Handler/JsonContentHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace EquipTests\Handler;
 
-use Equip\Exception\HttpBadRequestException;
+use Equip\Exception\HttpException;
 use Equip\Handler\JsonContentHandler;
 use Zend\Diactoros\Response;
 
@@ -22,20 +22,22 @@ class JsonContentHandlerTest extends ContentHandlerTestCase
         });
     }
 
-    /**
-     * @expectedException \Equip\Exception\HttpException
-     * @expectedExceptionCode 400
-     * @expectedExceptionMessageRegExp /json.* syntax error/i
-     */
     public function testInvokeWithMalformedBody()
     {
+        $this->setExpectedExceptionRegExp(
+            HttpException::class,
+            '/json.* syntax error/i',
+            400
+        );
+
         $request = $this->getRequest(
             $mime = 'application/json',
             $body = '{not json}'
         );
         $response = new Response;
         $handler = new JsonContentHandler;
-        $resolved = $handler($request, $response, function ($req, $res) {
+
+        $handler($request, $response, function ($req, $res) {
             $this->fail('Handler callback unexpectedly invoked');
         });
     }

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -68,7 +68,7 @@ class InputTest extends TestCase
     public function testUploadedFiles()
     {
         $files = [
-            'file' => $this->getMock(UploadedFileInterface::class),
+            'file' => $this->createMock(UploadedFileInterface::class),
         ];
 
         $request = new ServerRequest;
@@ -123,7 +123,7 @@ class InputTest extends TestCase
         $this->assertSame($value, $this->execute($request));
 
         $value = [
-            'merge' => $this->getMock(UploadedFileInterface::class),
+            'merge' => $this->createMock(UploadedFileInterface::class),
         ];
         $request = $request->withParsedBody($value);
         $this->assertSame($value, $this->execute($request));

--- a/tests/Middleware/MiddlewareSetTest.php
+++ b/tests/Middleware/MiddlewareSetTest.php
@@ -22,7 +22,7 @@ class MiddlewareSetTest extends TestCase
     public function testWithValidEntries()
     {
         $middleware = [
-            $this->getMock(MiddlewareInterface::class),
+            $this->createMock(MiddlewareInterface::class),
             function () {
             }
         ];

--- a/tests/Responder/FormattedResponderTest.php
+++ b/tests/Responder/FormattedResponderTest.php
@@ -121,8 +121,8 @@ class FormattedResponderTest extends ConfigurationTestCase
     public function testEmptyPayload()
     {
         $payload = new Payload;
-        $request = $this->getMock(ServerRequestInterface::class);
-        $response = $this->getMock(ResponseInterface::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
         $returned = call_user_func($this->responder, $request, $response, $payload);
         $this->assertSame($returned, $response);
     }


### PR DESCRIPTION
PHPUnit >= 5.2 requires PHP 5.6, but the Equip still supports PHP 5.5 (Travis CI)
[PHP 5.5 is no longer supported](https://secure.php.net/supported-versions.php), so it should be removed from the builds.

Now, every build has the warning that the `TestCase::getMock` method has been deprecated.

Ref: [equip/auth/pull/3](https://github.com/equip/auth/pull/3#issuecomment-223382877)