### PR TITLE
Improve exceptions

### DIFF
--- a/src/Exception/FormatterException.php
+++ b/src/Exception/FormatterException.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Equip\Exception;
+
+use Equip\Formatter\FormatterInterface;
+use InvalidArgumentException;
+
+class FormatterException extends InvalidArgumentException
+{
+    /**
+     * @param string|object $spec
+     *
+     * @return static
+     */
+    public static function invalidClass($spec)
+    {
+        if (is_object($spec)) {
+            $spec = get_class($spec);
+        }
+
+        return new static(sprintf(
+            'Formatter class `%s` must implement `%s`',
+            $spec,
+            FormatterInterface::class
+        ));
+    }
+
+    /**
+      * @param string|object $formatter
+      *
+      * @return static
+      */
+     public static function needsQuality($formatter)
+     {
+         if (is_object($formatter)) {
+             $formatter = get_class($formatter);
+         }
+
+         return new static(sprintf(
+             'No quality have been set for the `%s` formatter',
+             $formatter
+         ));
+     }
+}

--- a/src/Exception/MiddlewareException.php
+++ b/src/Exception/MiddlewareException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Equip\Exception;
+
+use DomainException;
+
+class MiddlewareException extends DomainException
+{
+    /**
+     * @param string|object $spec
+     *
+     * @return static
+     */
+    public static function notInvokable($spec)
+    {
+        if (is_object($spec)) {
+            $spec = get_class($spec);
+        }
+
+        return new static(sprintf(
+            'Middleware `%s` is not invokable',
+            $spec
+        ));
+    }
+}

--- a/src/Exception/ResponderException.php
+++ b/src/Exception/ResponderException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Equip\Exception;
+
+use Equip\Adr\ResponderInterface;
+use InvalidArgumentException;
+
+class ResponderException extends InvalidArgumentException
+{
+    /**
+     * @param string|object $spec
+     *
+     * @return static
+     */
+    public static function invalidClass($spec)
+    {
+        if (is_object($spec)) {
+            $spec = get_class($spec);
+        }
+
+        return new static(sprintf(
+            'Responder class `%s` must implement `%s`',
+            $spec,
+            ResponderInterface::class
+        ));
+    }
+}

--- a/src/Middleware/MiddlewareSet.php
+++ b/src/Middleware/MiddlewareSet.php
@@ -2,7 +2,7 @@
 
 namespace Equip\Middleware;
 
-use DomainException;
+use Equip\Exception\MiddlewareException;
 use Equip\Structure\Set;
 
 class MiddlewareSet extends Set
@@ -10,17 +10,16 @@ class MiddlewareSet extends Set
     /**
      * @inheritDoc
      *
-     * @throws \DomainException if $middlewares does not conform to type expectations
+     * @throws MiddlewareException
+     * If $classes does not conform to type expectations.
      */
-    protected function assertValid(array $middlewares)
+    protected function assertValid(array $classes)
     {
-        parent::assertValid($middlewares);
+        parent::assertValid($classes);
 
-        foreach ($middlewares as $middleware) {
+        foreach ($classes as $middleware) {
             if (!(is_callable($middleware) || method_exists($middleware, '__invoke'))) {
-                throw new DomainException(
-                    'All elements of $middlewares must be callable'
-                );
+                throw MiddlewareException::notInvokable($middleware);
             }
         }
     }

--- a/src/Middleware/MiddlewareSet.php
+++ b/src/Middleware/MiddlewareSet.php
@@ -11,7 +11,7 @@ class MiddlewareSet extends Set
      * @inheritDoc
      *
      * @throws MiddlewareException
-     * If $classes does not conform to type expectations.
+     *  If $classes does not conform to type expectations.
      */
     protected function assertValid(array $classes)
     {

--- a/src/Responder/ChainedResponder.php
+++ b/src/Responder/ChainedResponder.php
@@ -52,7 +52,7 @@ class ChainedResponder extends Set implements ResponderInterface
      * @inheritDoc
      *
      * @throws ResponderException
-     * If $classes does not implement the correct interface.
+     *  If $classes does not implement the correct interface.
      */
     protected function assertValid(array $classes)
     {

--- a/src/Responder/ChainedResponder.php
+++ b/src/Responder/ChainedResponder.php
@@ -4,9 +4,9 @@ namespace Equip\Responder;
 
 use Equip\Adr\PayloadInterface;
 use Equip\Adr\ResponderInterface;
+use Equip\Exception\ResponderException;
 use Equip\Resolver\ResolverTrait;
 use Equip\Structure\Set;
-use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Relay\ResolverInterface;
@@ -37,8 +37,8 @@ class ChainedResponder extends Set implements ResponderInterface
      */
     public function __invoke(
         ServerRequestInterface $request,
-        ResponseInterface      $response,
-        PayloadInterface       $payload
+        ResponseInterface $response,
+        PayloadInterface $payload
     ) {
         foreach ($this as $responder) {
             $responder = $this->resolve($responder);
@@ -51,19 +51,16 @@ class ChainedResponder extends Set implements ResponderInterface
     /**
      * @inheritDoc
      *
-     * @throws InvalidArgumentException If a responder does not implement the correct interface.
+     * @throws ResponderException
+     * If $classes does not implement the correct interface.
      */
-    protected function assertValid(array $data)
+    protected function assertValid(array $classes)
     {
-        parent::assertValid($data);
+        parent::assertValid($classes);
 
-        foreach ($data as $responder) {
+        foreach ($classes as $responder) {
             if (!is_subclass_of($responder, ResponderInterface::class)) {
-                throw new InvalidArgumentException(sprintf(
-                    'All responders in `%s` must implement `%s`',
-                    static::class,
-                    ResponderInterface::class
-                ));
+                throw ResponderException::invalidClass($responder);
             }
         }
     }

--- a/src/Responder/FormattedResponder.php
+++ b/src/Responder/FormattedResponder.php
@@ -4,11 +4,11 @@ namespace Equip\Responder;
 
 use Equip\Adr\PayloadInterface;
 use Equip\Adr\ResponderInterface;
+use Equip\Exception\FormatterException;
 use Equip\Formatter\FormatterInterface;
 use Equip\Formatter\JsonFormatter;
 use Equip\Resolver\ResolverTrait;
 use Equip\Structure\SortedDictionary;
-use InvalidArgumentException;
 use Negotiation\Negotiator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -139,28 +139,21 @@ class FormattedResponder extends SortedDictionary implements ResponderInterface
     /**
      * @inheritDoc
      *
-     * @throws InvalidArgumentException
-     *  If a formatter does not implement the correct interface, or does not
-     *  have a quality value.
+     * @throws FormatterException
+     *  If $classes does not implement the correct interface,
+     *  or does not have a quality value.
      */
-    protected function assertValid(array $data)
+    protected function assertValid(array $classes)
     {
-        parent::assertValid($data);
+        parent::assertValid($classes);
 
-        foreach ($data as $formatter => $quality) {
+        foreach ($classes as $formatter => $quality) {
             if (!is_subclass_of($formatter, FormatterInterface::class)) {
-                throw new InvalidArgumentException(sprintf(
-                    'All formatters in `%s` must implement `%s`',
-                    static::class,
-                    FormatterInterface::class
-                ));
+                throw FormatterException::invalidClass($formatter);
             }
 
             if (!is_float($quality)) {
-                throw new InvalidArgumentException(sprintf(
-                    'All formatters in `%s` must have a quality value',
-                    static::class
-                ));
+                throw FormatterException::needsQuality($formatter);
             }
         }
     }

--- a/tests/Middleware/MiddlewareSetTest.php
+++ b/tests/Middleware/MiddlewareSetTest.php
@@ -2,20 +2,21 @@
 
 namespace EquipTests\Middleware;
 
+use Equip\Exception\MiddlewareException;
 use Equip\Middleware\MiddlewareSet;
 use PHPUnit_Framework_TestCase as TestCase;
 use Relay\MiddlewareInterface;
 
 class MiddlewareSetTest extends TestCase
 {
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionRegExp /must be callable/i
-     */
     public function testWithInvalidEntries()
     {
-        $middleware = ['foo'];
-        $collection = new MiddlewareSet($middleware);
+        $this->setExpectedExceptionRegExp(
+            MiddlewareException::class,
+            '/Middleware .* is not invokable/i'
+        );
+
+        new MiddlewareSet(['foo']);
     }
 
     public function testWithValidEntries()

--- a/tests/Responder/ChainedResponderTest.php
+++ b/tests/Responder/ChainedResponderTest.php
@@ -6,6 +6,7 @@ use EquipTests\Configuration\ConfigurationTestCase;
 use Equip\Adr\PayloadInterface;
 use Equip\Adr\ResponderInterface;
 use Equip\Configuration\AurynConfiguration;
+use Equip\Exception\ResponderException;
 use Equip\Responder\ChainedResponder;
 use Equip\Responder\FormattedResponder;
 use Equip\Responder\RedirectResponder;
@@ -41,13 +42,14 @@ class ChainedResponderTest extends ConfigurationTestCase
         $this->assertContains(RedirectResponder::class, $responders);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /responders .* must implement .*ResponderInterface/i
-     */
     public function testInvalidResponder()
     {
-        $responder = $this->responder->withValue(get_class($this));
+        $this->setExpectedExceptionRegExp(
+            ResponderException::class,
+            '/Responder class .* must implement .*ResponderInterface/i'
+        );
+
+        $this->responder->withValue(get_class($this));
     }
 
     public function testAddResponder()

--- a/tests/Responder/FormattedResponderTest.php
+++ b/tests/Responder/FormattedResponderTest.php
@@ -4,11 +4,11 @@ namespace EquipTests\Responder;
 
 use EquipTests\Configuration\ConfigurationTestCase;
 use Equip\Configuration\AurynConfiguration;
+use Equip\Exception\FormatterException;
 use Equip\Formatter\FormatterInterface;
 use Equip\Formatter\JsonFormatter;
 use Equip\Payload;
 use Equip\Responder\FormattedResponder;
-use InvalidArgumentException;
 use Negotiation\Negotiator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -83,19 +83,21 @@ class FormattedResponderTest extends ConfigurationTestCase
     public function testInvalidResponder()
     {
         $this->setExpectedExceptionRegExp(
-            InvalidArgumentException::class,
-            '/formatters .* must implement .*FormatterInterface/i'
+            FormatterException::class,
+            '/Formatter class .* must implement .*FormatterInterface/i'
         );
-        $responder = $this->responder->withValue(get_class($this), 1.0);
+
+        $this->responder->withValue(get_class($this), 1.0);
     }
 
     public function testInvalidResponderQuality()
     {
         $this->setExpectedExceptionRegExp(
-            InvalidArgumentException::class,
-            '/formatters .* must have a quality/ii'
+            FormatterException::class,
+            '/No quality have been set for the .*/ii'
         );
-        $responder = $this->responder->withValue(JsonFormatter::class, false);
+
+        $this->responder->withValue(JsonFormatter::class, false);
     }
 
     public function testResponse()


### PR DESCRIPTION
Error messages are now more informative.
Use a separate file for exceptions improves readability and re-use, and allows to implement [marker (type) exception](https://github.com/AlexMasterov/framework/blob/c55618ae8071a733edaeedb53c93753109b5490e/src/Exception/ExceptionInterface.php) for [exceptions coming from the Equip](https://github.com/AlexMasterov/framework/blob/5be6b87cd3ab85eb78a08e40b523cf82e5c58112/src/Handler/ExceptionHandler.php#L79).

Ref: #56