### PR TITLE
Fix for exceptions

### DIFF
--- a/src/Exception/FormatterException.php
+++ b/src/Exception/FormatterException.php
@@ -8,16 +8,12 @@ use InvalidArgumentException;
 class FormatterException extends InvalidArgumentException
 {
     /**
-     * @param string|object $spec
+     * @param string $spec
      *
      * @return static
      */
     public static function invalidClass($spec)
     {
-        if (is_object($spec)) {
-            $spec = get_class($spec);
-        }
-
         return new static(sprintf(
             'Formatter class `%s` must implement `%s`',
             $spec,
@@ -26,16 +22,12 @@ class FormatterException extends InvalidArgumentException
     }
 
     /**
-      * @param string|object $formatter
+      * @param string $formatter
       *
       * @return static
       */
      public static function needsQuality($formatter)
      {
-         if (is_object($formatter)) {
-             $formatter = get_class($formatter);
-         }
-
          return new static(sprintf(
              'No quality have been set for the `%s` formatter',
              $formatter

--- a/src/Exception/ResponderException.php
+++ b/src/Exception/ResponderException.php
@@ -8,16 +8,12 @@ use InvalidArgumentException;
 class ResponderException extends InvalidArgumentException
 {
     /**
-     * @param string|object $spec
+     * @param string $spec
      *
      * @return static
      */
     public static function invalidClass($spec)
     {
-        if (is_object($spec)) {
-            $spec = get_class($spec);
-        }
-
         return new static(sprintf(
             'Responder class `%s` must implement `%s`',
             $spec,


### PR DESCRIPTION
Structure does not allow storage of objects :confused: [`Dictionary::hasValue`](https://github.com/equip/structure/blob/9bb7222d957061b83f4b7b2ae2f85920f8c3c466/src/Dictionary.php#L22)
> array_key_exists(): argument should be either a string or an integer

@shadowhand Please think about the use of [`spl_object_hash`](http://php.net/manual/en/function.spl-object-hash.php) for storing objects.