### PR TITLE
Switch from routing to split dispatching

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,140 @@
+Migrating
+=========
+
+Use this document to help you transition away from deprecated code.
+
+## Switching from Routing to Dispatching
+
+Version 3.0.0 replaces the routing callback with dispatching callables, which
+are typically defined as classes with an `__invoke` method in your project.
+
+### Changes
+
+Routing that used to be defined as:
+
+```php
+Application::build()
+// ...
+->setRouting(function (Equip\Directory $directory) {
+    return $directory
+        ->get('/', Domain\Welcome::class)
+        ->get('/hello[/{name}]', Domain\Hello::class)
+        ->post('/hello[/{name}]', Domain\Hello::class)
+        ; // End of routing
+})
+```
+
+Would now be defined as:
+
+```php
+Application::build()
+// ...
+->setDispatching([
+    Project\Hello\HelloDispatcher::class,
+    Project\Welcome\WelcomeDispatcher::class,
+])
+```
+
+### Temporary Solution
+
+As a temporary solution, you may reuse the routing function for dispatching:
+
+```php
+Application::build()
+// ...
+->setDispatching([
+    function (Equip\Directory $directory) {
+        return $directory
+            ->get('/', Domain\Welcome::class)
+            ->get('/hello[/{name}]', Domain\Hello::class)
+            ->post('/hello[/{name}]', Domain\Hello::class)
+            ; // End of routing
+    },
+])
+```
+
+
+### Splitting Dispatchers
+
+The long term solution for handling dispatching is to add separate classes for
+each resource you want to dispatch. Splitting the current routing would become:
+
+```php
+namespace Equip\Project\Hello;
+
+use Equip\Directory;
+
+class HelloDispatcher
+{
+    public function __invoke(Directory $directory)
+    {
+        return $directory
+            ->get('/hello[/{name}]', HelloDomain::class)
+            ->post('/hello[/{name}]', HelloDomain::class)
+            ;
+    }
+}
+```
+
+```php
+namespace Equip\Project\Welcome;
+
+use Equip\Directory;
+
+class WelcomeDispatcher
+{
+    public function __invoke(Directory $directory)
+    {
+        return $directory->get('/', WelcomeDomain::class);
+    }
+}
+```
+
+For simplicity, you may only want to have a single dispatcher when starting a
+new project and as your application grows you can switch to separate files.
+
+
+### Resource Based Structure
+
+This also implies a change towards resource-based code structure, as opposed to
+type-based structure. Instead of organizing your files by the type:
+
+```
+src/
+    Domain/
+        Hello.php
+        Welcome.php
+    Exceptions/
+        HelloError.php
+        WelcomeError.php
+```
+
+Files are logically grouped by the resource they represent:
+
+```
+src/
+    Hello/
+        HelloDomain.php
+        HelloError.php
+    Welcome/
+        WelcomeDomain.php
+        WelcomeError.php
+```
+
+It is recommended that your organize your Equip projects this way but not required.
+The benefit to doing so that it becomes very easy to determine what code can be
+found based on its name.
+
+If you have common code that is shared between different resource contexts, feel
+free to create a "common" directory:
+
+```
+src/
+    Common/
+        Filesystem.php
+        Database.php
+    Hello/
+        ...
+    Welcome/
+        ...
+```

--- a/src/Application.php
+++ b/src/Application.php
@@ -5,6 +5,7 @@ namespace Equip;
 use Auryn\Injector;
 use Equip\Configuration\ConfigurationSet;
 use Equip\Directory;
+use Equip\Dispatching\DispatchingSet;
 use Equip\Middleware\MiddlewareSet;
 use Relay\Relay;
 
@@ -16,15 +17,17 @@ class Application
      * @param Injector $injector
      * @param ConfigurationSet $configuration
      * @param MiddlewareSet $middleware
+     * @param DispatchingSet $dispatching
      *
      * @return static
      */
     public static function build(
         Injector $injector = null,
         ConfigurationSet $configuration = null,
-        MiddlewareSet $middleware = null
+        MiddlewareSet $middleware = null,
+        DispatchingSet $dispatching = null
     ) {
-        return new static($injector, $configuration, $middleware);
+        return new static($injector, $configuration, $middleware, $dispatching);
     }
 
     /**
@@ -43,23 +46,26 @@ class Application
     private $middleware;
 
     /**
-     * @var callable|string
+     * @var DispatchingSet
      */
-    private $routing;
+    private $dispatching;
 
     /**
      * @param Injector $injector
      * @param ConfigurationSet $configuration
      * @param MiddlewareSet $middleware
+     * @param DispatchingSet $dispatching
      */
     public function __construct(
         Injector $injector = null,
         ConfigurationSet $configuration = null,
-        MiddlewareSet $middleware = null
+        MiddlewareSet $middleware = null,
+        DispatchingSet $dispatching = null
     ) {
         $this->injector = $injector ?: new Injector;
         $this->configuration = $configuration ?: new ConfigurationSet;
         $this->middleware = $middleware ?: new MiddlewareSet;
+        $this->dispatching = $dispatching ?: new DispatchingSet;
     }
 
     /**
@@ -89,15 +95,15 @@ class Application
     }
 
     /**
-     * Change routing
+     * Change dispatching
      *
-     * @param callable|string $routing
+     * @param array $dispatching
      *
      * @return self
      */
-    public function setRouting($routing)
+    public function setDispatching(array $dispatching)
     {
-        $this->routing = $routing;
+        $this->dispatching = $this->dispatching->withValues($dispatching);
         return $this;
     }
 
@@ -114,7 +120,7 @@ class Application
 
         return $this->injector
             ->share($this->middleware)
-            ->prepare(Directory::class, $this->routing)
+            ->prepare(Directory::class, $this->dispatching)
             ->execute($runner);
     }
 }

--- a/src/Dispatching/DispatchingSet.php
+++ b/src/Dispatching/DispatchingSet.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Equip\Dispatching;
+
+use Auryn\Injector;
+use Equip\Directory;
+use Equip\Exception\DispatchingException;
+use Equip\Structure\Set;
+
+class DispatchingSet extends Set
+{
+    /**
+     * Handle directory preparation for injection.
+     *
+     * Applies each of the dispatchers in the current set to the directory.
+     *
+     * @param Directory $directory
+     * @param Injector $injector
+     *
+     * @return Directory
+     */
+    public function __invoke(Directory $directory, Injector $injector)
+    {
+        foreach ($this as $dispatch) {
+            if (!is_callable($dispatch)) {
+                $dispatch = $injector->make($dispatch);
+            }
+            $directory = $dispatch($directory);
+        }
+
+        return $directory;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws DispatchingException
+     *  If $classes does not conform to type expectations.
+     */
+    protected function assertValid(array $classes)
+    {
+        parent::assertValid($classes);
+
+        foreach ($classes as $dispatching) {
+            if (!(is_callable($dispatching) || method_exists($dispatching, '__invoke'))) {
+                throw DispatchingException::notInvokable($dispatching);
+            }
+        }
+    }
+}

--- a/src/Exception/DispatchingException.php
+++ b/src/Exception/DispatchingException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Equip\Exception;
+
+use InvalidArgumentException;
+
+class DispatchingException extends InvalidArgumentException
+{
+    /**
+     * @param string|object $spec
+     *
+     * @return static
+     */
+    public static function notInvokable($spec)
+    {
+        if (is_object($spec)) {
+            $spec = get_class($spec);
+        }
+
+        return new static(sprintf(
+            'Dispatcher `%s` is not invokable',
+            $spec
+        ));
+    }
+}

--- a/tests/Dispatching/DispatchingSetTest.php
+++ b/tests/Dispatching/DispatchingSetTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace EquipTests\Dispatching;
+
+use Auryn\Injector;
+use Equip\Adr\DomainInterface;
+use Equip\Directory;
+use Equip\Exception\DispatchingException;
+use Equip\Dispatching\DispatchingSet;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class DispatchingSetTest extends TestCase
+{
+    public function testWithInvalidEntries()
+    {
+        $this->setExpectedExceptionRegExp(
+            DispatchingException::class,
+            '/Dispatcher .* is not invokable/i'
+        );
+
+        new DispatchingSet([__CLASS__]);
+    }
+
+    public function testWithValidEntries()
+    {
+        $dispatchers = [
+            function () {
+            }
+        ];
+        $dispatching = new DispatchingSet($dispatchers);
+        $this->assertSame($dispatchers, $dispatching->toArray());
+    }
+
+    public function testPrepareDirectory()
+    {
+        $dispatchers = [
+            function (Directory $directory) {
+                return $directory->get('/', DomainInterface::class);
+            }
+        ];
+
+        $dispatching = new DispatchingSet($dispatchers);
+        $directory = new Directory;
+
+        $prepared = $dispatching($directory, $this->getMock(Injector::class));
+
+        $this->assertInstanceOf(Directory::class, $prepared);
+        $this->assertNotSame($prepared, $directory);
+    }
+}


### PR DESCRIPTION
Rather than having a single large routing table, split routing into
separate dispatching classes, similar to a middleware set.

See [MIGRATING.md](https://github.com/equip/framework/blob/feature/dispatch-routing/MIGRATING.md) for how it would look to users.