### PR TITLE
Fix ConfigurationException

### DIFF
--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -8,12 +8,16 @@ use Equip\Configuration\ConfigurationInterface;
 class ConfigurationException extends DomainException
 {
     /**
-     * @param string $spec
+     * @param string|object $spec
      *
      * @return static
      */
     public static function invalidClass($spec)
     {
+        if (is_object($spec)) {
+            $spec = get_class($spec);
+        }
+
         return new static(sprintf(
             'Configuration class `%s` must implement `%s`',
             $spec,


### PR DESCRIPTION
A configuration may be an existing object. [`Set::hasValue`](https://github.com/equip/structure/blob/9bb7222d957061b83f4b7b2ae2f85920f8c3c466/src/Set.php#L13) (`in_array`)

**TL;DR:**
```php
class ConfigWithoutInterfaceType
{
}

Equip\Application::build()
->setConfiguration([
    new ConfigWithoutInterfaceType,
// ...
```
> Catchable fatal error: Object of class Index could not be converted to string

Another case: #62. Really need to update tests for these cases.