### PR TITLE
Enable dispatching inside of sub-directory

### DIFF
--- a/src/Directory.php
+++ b/src/Directory.php
@@ -18,6 +18,51 @@ class Directory extends Dictionary
     const OPTIONS = 'OPTIONS';
 
     /**
+     * @var string
+     */
+    private $prefix = '';
+
+    /**
+     * Set the directory path prefix.
+     *
+     * @param string $prefix
+     *
+     * @return static
+     */
+    public function withPrefix($prefix)
+    {
+        $copy = clone $this;
+        $copy->prefix = '/' . trim($prefix, '/');
+
+        return $copy;
+    }
+
+    /**
+     * Remove the directory path prefix.
+     *
+     * @return static
+     */
+    public function withoutPrefix()
+    {
+        $copy = clone $this;
+        $copy->prefix = '';
+
+        return $copy;
+    }
+
+    /**
+     * Add the prefix to a path.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    public function prefix($path)
+    {
+        return $this->prefix . $path;
+    }
+
+    /**
      * @param string $path
      * @param string|Action $domainOrAction
      *

--- a/src/Handler/DispatchHandler.php
+++ b/src/Handler/DispatchHandler.php
@@ -60,7 +60,12 @@ class DispatchHandler
         return FastRoute\simpleDispatcher(function (RouteCollector $collector) {
             foreach ($this->directory as $request => $action) {
                 list($method, $path) = explode(' ', $request, 2);
-                $collector->addRoute($method, $path, $action);
+
+                $collector->addRoute(
+                    $method,
+                    $this->directory->prefix($path),
+                    $action
+                );
             }
         });
     }

--- a/tests/DirectoryTest.php
+++ b/tests/DirectoryTest.php
@@ -78,4 +78,15 @@ class DirectoryTest extends DirectoryTestCase
             ['OPTIONS']
         ];
     }
+
+    public function testPrefix()
+    {
+        $directory = $this->directory->withPrefix('/test/');
+
+        $this->assertSame('/test/path', $directory->prefix('/path'));
+
+        $directory = $this->directory->withoutPrefix();
+
+        $this->assertSame('/same', $directory->prefix('/same'));
+    }
 }

--- a/tests/Handler/DispatchHandlerTest.php
+++ b/tests/Handler/DispatchHandlerTest.php
@@ -38,6 +38,23 @@ class DispatchHandlerTest extends DirectoryTestCase
         $this->dispatch($directory, $request, $response, $next);
     }
 
+    public function testPrefixed()
+    {
+        $action = $this->getMockAction();
+        $directory = $this->directory->withPrefix('prefix');
+        $directory = $directory->get('/[{name}]', $action);
+        $request = $this->getRequest('GET', '/prefix/tester');
+        $response = new Response;
+
+        $next = function (ServerRequest $request, Response $response) use ($action) {
+            $this->assertSame($action, $request->getAttribute(ActionHandler::ACTION_ATTRIBUTE));
+            $this->assertSame('tester', $request->getAttribute('name'));
+            return $response;
+        };
+
+        $this->dispatch($directory, $request, $response, $next);
+    }
+
     /**
      * @expectedException \Equip\Exception\HttpException
      * @expectedExceptionRegExp /cannot find any resource at/i


### PR DESCRIPTION
When installing Equip inside of a sub-directory it is undesirable to
manually add the directory name to every route. Add prefix support to
Directory collector to handle this.