### PR TITLE
Remove payload from formatting

### DIFF
--- a/src/Formatter/FormatterInterface.php
+++ b/src/Formatter/FormatterInterface.php
@@ -2,8 +2,6 @@
 
 namespace Equip\Formatter;
 
-use Equip\Adr\PayloadInterface;
-
 interface FormatterInterface
 {
     /**
@@ -14,18 +12,18 @@ interface FormatterInterface
     public static function accepts();
 
     /**
-     * Get the content type of the response body.
+     * Get the content type this formatter will generate.
      *
      * @return string
      */
     public function type();
 
     /**
-     * Get the response body from the payload.
+     * Get the formatted version of provided content.
      *
-     * @param PayloadInterface $payload
+     * @param mixed $content
      *
      * @return string
      */
-    public function body(PayloadInterface $payload);
+    public function format($content);
 }

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -2,8 +2,6 @@
 
 namespace Equip\Formatter;
 
-use Equip\Adr\PayloadInterface;
-
 class JsonFormatter implements FormatterInterface
 {
     /**
@@ -25,9 +23,9 @@ class JsonFormatter implements FormatterInterface
     /**
      * @inheritDoc
      */
-    public function body(PayloadInterface $payload)
+    public function format($content)
     {
-        return json_encode($payload->getOutput(), $this->options());
+        return json_encode($content, $this->options());
     }
 
     /**

--- a/src/Formatter/PlatesFormatter.php
+++ b/src/Formatter/PlatesFormatter.php
@@ -2,7 +2,6 @@
 
 namespace Equip\Formatter;
 
-use Equip\Adr\PayloadInterface;
 use Equip\Formatter\HtmlFormatter;
 use League\Plates\Engine;
 
@@ -14,6 +13,11 @@ class PlatesFormatter extends HtmlFormatter
     private $engine;
 
     /**
+     * @var string
+     */
+    private $template;
+
+    /**
      * @param Engine $engine
      */
     public function __construct(Engine $engine)
@@ -22,23 +26,25 @@ class PlatesFormatter extends HtmlFormatter
     }
 
     /**
-     * @inheritDoc
+     * Get a copy that uses a different template.
+     *
+     * @param string $template
+     *
+     * @return static
      */
-    public function body(PayloadInterface $payload)
+    public function withTemplate($template)
     {
-        return $this->render($payload);
+        $copy = clone $this;
+        $copy->template = $template;
+
+        return $copy;
     }
 
     /**
-     * @param PayloadInterface $payload
-     *
-     * @return string
+     * @inheritDoc
      */
-    private function render(PayloadInterface $payload)
+    public function format($content)
     {
-        $template = $payload->getSetting('template');
-        $output = $payload->getOutput();
-
-        return $this->engine->render($template, $output);
+        return $this->engine->render($this->template, $content);
     }
 }

--- a/tests/Formatter/HtmlFormatterTest.php
+++ b/tests/Formatter/HtmlFormatterTest.php
@@ -3,7 +3,6 @@
 namespace EquipTests\Formatter;
 
 use Equip\Formatter\HtmlFormatter;
-use Equip\Payload;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class HtmlFormatterTest extends TestCase

--- a/tests/Formatter/JsonFormatterTest.php
+++ b/tests/Formatter/JsonFormatterTest.php
@@ -3,7 +3,6 @@
 namespace EquipTests\Formatter;
 
 use Equip\Formatter\JsonFormatter;
-use Equip\Payload;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class JsonFormatterTest extends TestCase
@@ -30,11 +29,11 @@ class JsonFormatterTest extends TestCase
 
     public function testBody()
     {
-        $payload = (new Payload)->withOutput([
+        $content = [
             'success' => true,
-        ]);
+        ];
 
-        $body = $this->formatter->body($payload);
+        $body = $this->formatter->format($content);
 
         $this->assertEquals('{"success":true}', $body);
     }

--- a/tests/Formatter/PlatesFormatterTest.php
+++ b/tests/Formatter/PlatesFormatterTest.php
@@ -2,7 +2,6 @@
 
 namespace EquipTests\Formatter;
 
-use Equip\Adr\PayloadInterface;
 use Equip\Formatter\PlatesFormatter;
 use League\Plates\Engine;
 use PHPUnit_Framework_TestCase as TestCase;
@@ -38,23 +37,15 @@ class PlatesFormatterTest extends TestCase
     public function testResponse()
     {
         $template = 'test';
-        $output = [
+        $content = [
             'header' => 'header',
             'body'   => 'body',
             'footer' => 'footer'
         ];
 
-        $payload = $this->createMock(PayloadInterface::class);
-
-        $payload->expects($this->any())
-            ->method('getSetting')
-            ->willReturn($template);
-
-        $payload->expects($this->any())
-            ->method('getOutput')
-            ->willReturn($output);
-
-        $body = $this->formatter->body($payload);
+        $body = $this->formatter
+            ->withTemplate($template)
+            ->format($content);
 
         $this->assertEquals("<h1>header</h1>\n<p>body</p>\n<span>footer</span>\n", $body);
     }


### PR DESCRIPTION
Coupling formatting to payloads has made formatting arbitrary content
much harder and does not provide a clear separation of concerns.

Allowing formatters to format content from any context provides greater
potential for reuse and will work better with custom responders that
may not use payloads at all.

Refs #76 