### PR TITLE
Make ActionInterface use ServerRequestInterface

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -378,7 +378,6 @@ namespace Acme\Action;
 use Acme\Domain\Authentication;
 use Acme\Input\LoginInput;
 use Equip\Contract\ActionInterface;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -402,7 +401,7 @@ class LoginAction implements ActionInterface
         $this->responder = $responder;
     }
 
-    public function __invoke(RequestInterface $request, ResponseInterface $response)
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
         $input = $this->input($request);
         $errors = $this->auth->validate($input);

--- a/src/Contract/ActionInterface.php
+++ b/src/Contract/ActionInterface.php
@@ -2,7 +2,7 @@
 
 namespace Equip\Contract;
 
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 interface ActionInterface
@@ -13,13 +13,13 @@ interface ActionInterface
      * Parses request input and invokes domain logic. Formats domain output for
      * the response.
      *
-     * @param RequestInterface $request
+     * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      *
      * @return ResponseInterface
      */
     public function __invoke(
-        RequestInterface $request,
+        ServerRequestInterface $request,
         ResponseInterface $response
     );
 }


### PR DESCRIPTION
Although ActionHandler deals exclusively with ServerRequestInterface
instead of RequestInterface, ActionInterface used just
RequestInterface. This made it impossible for actions to use the
helpful features that ServerRequestInterface offers.

In particular, this bug actually rendered the example Action code in
the docs incorrect, because the variable $request (of type
RequestInterface) was passed as a parameter to input(), which expected
ServerRequestInterface.