### PR TITLE
Prevent whoops from sending output directly

### DIFF
--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -104,6 +104,8 @@ class ExceptionHandler
             $handler = $this->handler($type);
             $this->whoops->pushHandler($handler);
 
+            $this->whoops->writeToOutput(false);
+            $this->whoops->allowQuit(false);
             $body = $this->whoops->handleException($e);
             $response->getBody()->write($body);
 


### PR DESCRIPTION
Response status codes set by exceptions were getting lost because
Whoops was outputting early before ExceptionHandler had a
chance to return the correct response.