### PR TITLE
Fix to remove debug stack traces in production environments

### DIFF
--- a/src/Configuration/WhoopsConfiguration.php
+++ b/src/Configuration/WhoopsConfiguration.php
@@ -9,6 +9,8 @@ use Whoops\Run as Whoops;
 
 class WhoopsConfiguration implements ConfigurationInterface
 {
+    use EnvTrait;
+
     /**
      * @inheritDoc
      */
@@ -26,7 +28,9 @@ class WhoopsConfiguration implements ConfigurationInterface
      */
     public function prepareWhoops(Whoops $whoops)
     {
-        set_error_handler([$whoops, Whoops::ERROR_HANDLER]);
+        if($this->env->getValue('DEBUG_STACKTRACE', false) == true) {
+            set_error_handler([$whoops, Whoops::ERROR_HANDLER]);
+        }
 
         $whoops->writeToOutput(false);
         $whoops->allowQuit(false);

--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -101,7 +101,7 @@ class ExceptionHandler
                 $response = $e->withResponse($response);
             }
 
-            if ($this->preferences->displayDebug( )) {
+            if ($this->preferences->displayDebug()) {
 
                 $handler = $this->handler($type);
                 $this->whoops->pushHandler($handler);

--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -101,13 +101,16 @@ class ExceptionHandler
                 $response = $e->withResponse($response);
             }
 
-            $handler = $this->handler($type);
-            $this->whoops->pushHandler($handler);
+            if ($this->preferences->displayDebug( )) {
 
-            $body = $this->whoops->handleException($e);
-            $response->getBody()->write($body);
+                $handler = $this->handler($type);
+                $this->whoops->pushHandler($handler);
 
-            $this->whoops->popHandler();
+                $body = $this->whoops->handleException($e);
+                $response->getBody()->write($body);
+
+                $this->whoops->popHandler();
+            }
 
             return $response;
         }

--- a/src/Handler/ExceptionHandlerPreferences.php
+++ b/src/Handler/ExceptionHandlerPreferences.php
@@ -2,6 +2,7 @@
 
 namespace Equip\Handler;
 
+use Equip\Env;
 use Equip\Structure\Dictionary;
 use Whoops\Handler\JsonResponseHandler;
 use Whoops\Handler\PlainTextHandler;
@@ -10,10 +11,16 @@ use Whoops\Handler\XmlResponseHandler;
 
 class ExceptionHandlerPreferences extends Dictionary
 {
+
+    /**
+     * @var UserRepository
+     */
+    private $debug;
+
     /**
      * @inheritDoc
      */
-    public function __construct(array $data = [])
+    public function __construct(array $data = [], Env $env)
     {
         $data += [
             'text/html' => PrettyPageHandler::class,
@@ -28,6 +35,12 @@ class ExceptionHandlerPreferences extends Dictionary
             'text/plain' => PlainTextHandler::class,
         ]; // @codeCoverageIgnore
 
+        $this->debug = (bool) $env->getValue('DEBUG_STACKTRACE', false);
         parent::__construct($data);
+    }
+
+    public function displayDebug( )
+    {
+        return $this->debug;
     }
 }

--- a/tests/Handler/ExceptionHandlerPreferencesTest.php
+++ b/tests/Handler/ExceptionHandlerPreferencesTest.php
@@ -2,6 +2,7 @@
 
 namespace EquipTests\Handler;
 
+use Equip\Env;
 use Equip\Handler\ExceptionHandlerPreferences;
 use PHPUnit_Framework_TestCase as TestCase;
 use Whoops\Handler\JsonResponseHandler;
@@ -14,7 +15,13 @@ class ExceptionHandlerPreferencesTest extends TestCase
 {
     public function testConstruct()
     {
-        $prefs = new ExceptionHandlerPreferences;
+        $env = $this->getMock(Env::class);
+        $env->expects($this->atLeastOnce())
+            ->method('getValue')
+            ->with('DEBUG_STACKTRACE', false)
+            ->willReturn('1');
+
+        $prefs = new ExceptionHandlerPreferences([], $env);
 
         $this->assertNotContains(SoapHandler::class, $prefs);
 

--- a/tests/Handler/ExceptionHandlerTest.php
+++ b/tests/Handler/ExceptionHandlerTest.php
@@ -3,12 +3,13 @@
 namespace EquipTests\Handler;
 
 use Auryn\Injector;
-use EquipTests\Configuration\ConfigurationTestCase;
 use Equip\Configuration\AurynConfiguration;
 use Equip\Configuration\ConfigurationInterface;
 use Equip\Configuration\WhoopsConfiguration;
+use Equip\Env;
 use Equip\Exception\HttpException;
 use Equip\Handler\ExceptionHandler;
+use EquipTests\Configuration\ConfigurationTestCase;
 use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Log\LoggerInterface;
 use Zend\Diactoros\Response;
@@ -18,10 +19,16 @@ class ExceptionHandlerTest extends ConfigurationTestCase
 {
     protected function getConfigurations()
     {
+        $env = $this->getMock(Env::class);
+        $env->expects($this->atLeastOnce())
+            ->method('getValue')
+            ->with('DEBUG_STACKTRACE', false)
+            ->willReturn('1');
+
         return [
             new AurynConfiguration,
             new MockMonologConfiguration,
-            new WhoopsConfiguration,
+            new WhoopsConfiguration($env),
         ];
     }
 


### PR DESCRIPTION
Remove debug stack traces unless the DEBUG_STACKTRACE=1 environment variable is configured.